### PR TITLE
Add C++ metrics and tracing command

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,22 @@ workspace(name = "grpc_example")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "com_google_googleapis",
+    sha256 = "150be57ff83646e5652e03683c949f0830d9a0e73ef787786864210e45537fe0",
+    strip_prefix = "googleapis-6e3b55e26bf5a9f7874b6ba1411a0cc50cb87a48",
+    urls = ["https://github.com/googleapis/googleapis/archive/6e3b55e26bf5a9f7874b6ba1411a0cc50cb87a48.zip"],
+)
+
+# Google APIs - used by Stackdriver exporter.
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+http_archive(
     name = "com_github_grpc_grpc",
     urls = [
         "https://github.com/grpc/grpc/archive/v1.31.0.tar.gz",

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -31,6 +31,7 @@ cc_binary(
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/stats:stats",
 	      "@io_opencensus_cpp//opencensus/trace:trace",
+	      "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -48,6 +49,7 @@ cc_binary(
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/stats:stats",
 	      "@io_opencensus_cpp//opencensus/trace:trace",
+	      "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -64,5 +66,6 @@ cc_binary(
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/stats:stats",
 	      "@io_opencensus_cpp//opencensus/trace:trace",
+	      "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -8,7 +8,11 @@ cc_binary(
         "//:stats_proto",
         "//:wallet_proto",
         "@com_github_grpc_grpc//:grpc++",
-
+        "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+        "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
     ],
 )
 
@@ -22,6 +26,11 @@ cc_binary(
         "//:wallet_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
+        "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+        "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
     ],
 )
 
@@ -34,6 +43,11 @@ cc_binary(
         "//:stats_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
+        "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+        "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
     ],
 )
 
@@ -45,5 +59,10 @@ cc_binary(
         "//:account_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
+        "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+        "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
     ],
 )

--- a/cpp/account_server.cc
+++ b/cpp/account_server.cc
@@ -24,7 +24,10 @@
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/opencensus.h>
 
+#include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
+#include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
 #include "proto/grpc/examples/wallet/account/account.grpc.pb.h"
 
 using grpc::examples::wallet::account::Account;
@@ -92,8 +95,10 @@ void RunServer(const std::string& port, const std::string& hostname_suffix) {
 int main(int argc, char** argv) {
   std::string port = "50053";
   std::string hostname_suffix = "";
+  std::string observability_project = "";
   std::string arg_str_port("--port");
   std::string arg_str_hostname_suffix("--hostname_suffix");
+  std::string arg_str_observability_project("--observability_project");
   for (int i = 1; i < argc; ++i) {
     std::string arg_val = argv[i];
     size_t start_pos = arg_val.find(arg_str_port);
@@ -119,9 +124,36 @@ int main(int argc, char** argv) {
         return 1;
       }
     }
+    start_pos = arg_val.find(arg_str_observability_project);
+    if (start_pos != std::string::npos) {
+      start_pos += arg_str_observability_project.size();
+      if (arg_val[start_pos] == '=') {
+        observability_project = arg_val.substr(start_pos + 1);
+        continue;
+      } else {
+        std::cout << "The only correct argument syntax is --observability_project=" << std::endl;
+        return 1;
+      }
+    }
   }
   std::cout << "Account Server arguments: port: " << port
-            << ", hostname_suffix: " << hostname_suffix << std::endl;
+            << ", hostname_suffix: " << hostname_suffix
+            << ", observability_project: " << observability_project
+            << std::endl;
+  if (!observability_project.empty()) {
+    grpc::RegisterOpenCensusPlugin();
+    grpc::RegisterOpenCensusViewsForExport();
+    opencensus::trace::TraceConfig::SetCurrentTraceParams(
+        {128, 128, 128, 128, opencensus::trace::ProbabilitySampler(1.0)});
+    opencensus::exporters::trace::StackdriverOptions trace_opts;
+    trace_opts.project_id = observability_project;
+    opencensus::exporters::trace::StackdriverExporter::Register(
+      std::move(trace_opts));
+    opencensus::exporters::stats::StackdriverOptions stats_opts;
+    stats_opts.project_id = observability_project;
+    opencensus::exporters::stats::StackdriverExporter::Register(
+        std::move(stats_opts));
+  }
   RunServer(port, hostname_suffix);
   return 0;
 }

--- a/cpp/account_server.cc
+++ b/cpp/account_server.cc
@@ -160,6 +160,8 @@ int main(int argc, char** argv) {
         std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
+    // This must be unique among all processes exporting to Stackdriver
+    stats_opts.opencensus_task = "account-server-" + std::to_string(getpid());
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }

--- a/cpp/account_server.cc
+++ b/cpp/account_server.cc
@@ -16,29 +16,29 @@
  *
  */
 
-#include <unistd.h>
-#include <iostream>
-#include <memory>
-#include <string>
-
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/opencensus.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
 
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
 #include "proto/grpc/examples/wallet/account/account.grpc.pb.h"
 
-using grpc::examples::wallet::account::Account;
-using grpc::examples::wallet::account::GetUserInfoRequest;
-using grpc::examples::wallet::account::GetUserInfoResponse;
-using grpc::examples::wallet::account::MembershipType;
 using grpc::Server;
 using grpc::ServerBuilder;
 using grpc::ServerContext;
 using grpc::Status;
 using grpc::StatusCode;
+using grpc::examples::wallet::account::Account;
+using grpc::examples::wallet::account::GetUserInfoRequest;
+using grpc::examples::wallet::account::GetUserInfoResponse;
+using grpc::examples::wallet::account::MembershipType;
 
 class AccountServiceImpl final : public Account::Service {
  public:
@@ -131,7 +131,9 @@ int main(int argc, char** argv) {
         observability_project = arg_val.substr(start_pos + 1);
         continue;
       } else {
-        std::cout << "The only correct argument syntax is --observability_project=" << std::endl;
+        std::cout
+            << "The only correct argument syntax is --observability_project="
+            << std::endl;
         return 1;
       }
     }
@@ -148,7 +150,7 @@ int main(int argc, char** argv) {
     opencensus::exporters::trace::StackdriverOptions trace_opts;
     trace_opts.project_id = observability_project;
     opencensus::exporters::trace::StackdriverExporter::Register(
-      std::move(trace_opts));
+        std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
     opencensus::exporters::stats::StackdriverExporter::Register(

--- a/cpp/client.cc
+++ b/cpp/client.cc
@@ -18,6 +18,7 @@
 
 #include <grpc++/grpc++.h>
 #include <grpcpp/opencensus.h>
+#include <unistd.h>
 
 #include <iostream>
 #include <memory>
@@ -358,6 +359,8 @@ int main(int argc, char** argv) {
         std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
+    // This must be unique among all processes exporting to Stackdriver
+    stats_opts.opencensus_task = "client-" + std::to_string(getpid());
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }

--- a/cpp/client.cc
+++ b/cpp/client.cc
@@ -16,31 +16,30 @@
  *
  */
 
+#include <grpc++/grpc++.h>
+#include <grpcpp/opencensus.h>
+
 #include <iostream>
 #include <memory>
 #include <string>
 #include <thread>
-
-#include <grpc++/grpc++.h>
-#include <grpcpp/opencensus.h>
 
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
 #include "proto/grpc/examples/wallet/stats/stats.grpc.pb.h"
 #include "proto/grpc/examples/wallet/wallet.grpc.pb.h"
 
-
 using grpc::Channel;
 using grpc::ChannelArguments;
 using grpc::ClientContext;
 using grpc::ClientReader;
 using grpc::Status;
-using grpc::examples::wallet::stats::PriceRequest;
-using grpc::examples::wallet::stats::PriceResponse;
-using grpc::examples::wallet::stats::Stats;
 using grpc::examples::wallet::BalanceRequest;
 using grpc::examples::wallet::BalanceResponse;
 using grpc::examples::wallet::Wallet;
+using grpc::examples::wallet::stats::PriceRequest;
+using grpc::examples::wallet::stats::PriceResponse;
+using grpc::examples::wallet::stats::Stats;
 
 class WalletClient {
  public:
@@ -209,8 +208,6 @@ class StatsClient {
 };
 
 int main(int argc, char** argv) {
-
-
   std::string command = "balance";
   std::string wallet_server = "localhost:18881";
   std::string stats_server = "localhost:18882";
@@ -336,7 +333,9 @@ int main(int argc, char** argv) {
         observability_project = arg_val.substr(start_pos + 1);
         continue;
       } else {
-        std::cout << "The only correct argument syntax is --observability_project=" << std::endl;
+        std::cout
+            << "The only correct argument syntax is --observability_project="
+            << std::endl;
         return 1;
       }
     }
@@ -356,7 +355,7 @@ int main(int argc, char** argv) {
     opencensus::exporters::trace::StackdriverOptions trace_opts;
     trace_opts.project_id = observability_project;
     opencensus::exporters::trace::StackdriverExporter::Register(
-      std::move(trace_opts));
+        std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
     opencensus::exporters::stats::StackdriverExporter::Register(

--- a/cpp/stats_server.cc
+++ b/cpp/stats_server.cc
@@ -302,6 +302,8 @@ int main(int argc, char** argv) {
         std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
+    // This must be unique among all processes exporting to Stackdriver
+    stats_opts.opencensus_task = "stats-server-" + std::to_string(getpid());
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }

--- a/cpp/stats_server.cc
+++ b/cpp/stats_server.cc
@@ -16,7 +16,12 @@
  *
  */
 
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/opencensus.h>
 #include <unistd.h>
+
 #include <cmath>
 #include <ctime>
 #include <iostream>
@@ -24,23 +29,11 @@
 #include <string>
 #include <thread>
 
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
-#include <grpcpp/opencensus.h>
-
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
 #include "proto/grpc/examples/wallet/account/account.grpc.pb.h"
 #include "proto/grpc/examples/wallet/stats/stats.grpc.pb.h"
 
-using grpc::examples::wallet::account::Account;
-using grpc::examples::wallet::account::GetUserInfoRequest;
-using grpc::examples::wallet::account::GetUserInfoResponse;
-using grpc::examples::wallet::account::MembershipType;
-using grpc::examples::wallet::stats::PriceRequest;
-using grpc::examples::wallet::stats::PriceResponse;
-using grpc::examples::wallet::stats::Stats;
 using grpc::Channel;
 using grpc::ChannelArguments;
 using grpc::ClientContext;
@@ -50,6 +43,13 @@ using grpc::ServerContext;
 using grpc::ServerWriter;
 using grpc::Status;
 using grpc::StatusCode;
+using grpc::examples::wallet::account::Account;
+using grpc::examples::wallet::account::GetUserInfoRequest;
+using grpc::examples::wallet::account::GetUserInfoResponse;
+using grpc::examples::wallet::account::MembershipType;
+using grpc::examples::wallet::stats::PriceRequest;
+using grpc::examples::wallet::stats::PriceResponse;
+using grpc::examples::wallet::stats::Stats;
 
 class StatsServiceImpl final : public Stats::Service {
  public:
@@ -265,7 +265,9 @@ int main(int argc, char** argv) {
         observability_project = arg_val.substr(start_pos + 1);
         continue;
       } else {
-        std::cout << "The only correct argument syntax is --observability_project=" << std::endl;
+        std::cout
+            << "The only correct argument syntax is --observability_project="
+            << std::endl;
         return 1;
       }
     }
@@ -284,7 +286,7 @@ int main(int argc, char** argv) {
     opencensus::exporters::trace::StackdriverOptions trace_opts;
     trace_opts.project_id = observability_project;
     opencensus::exporters::trace::StackdriverExporter::Register(
-      std::move(trace_opts));
+        std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
     opencensus::exporters::stats::StackdriverExporter::Register(

--- a/cpp/stats_server.cc
+++ b/cpp/stats_server.cc
@@ -27,7 +27,10 @@
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/opencensus.h>
 
+#include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
+#include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
 #include "proto/grpc/examples/wallet/account/account.grpc.pb.h"
 #include "proto/grpc/examples/wallet/stats/stats.grpc.pb.h"
 
@@ -190,10 +193,12 @@ int main(int argc, char** argv) {
   std::string account_server = "localhost:50053";
   std::string hostname_suffix = "";
   bool premium_only = false;
+  std::string observability_project = "";
   std::string arg_str_port("--port");
   std::string arg_str_account_server("--account_server");
   std::string arg_str_hostname_suffix("--hostname_suffix");
   std::string arg_str_premium_only("--premium_only");
+  std::string arg_str_observability_project("--observability_project");
   for (int i = 1; i < argc; ++i) {
     std::string arg_val = argv[i];
     size_t start_pos = arg_val.find(arg_str_port);
@@ -253,11 +258,38 @@ int main(int argc, char** argv) {
         return 1;
       }
     }
+    start_pos = arg_val.find(arg_str_observability_project);
+    if (start_pos != std::string::npos) {
+      start_pos += arg_str_observability_project.size();
+      if (arg_val[start_pos] == '=') {
+        observability_project = arg_val.substr(start_pos + 1);
+        continue;
+      } else {
+        std::cout << "The only correct argument syntax is --observability_project=" << std::endl;
+        return 1;
+      }
+    }
   }
   std::cout << "Stats Server arguments: port: " << port
             << ", account_server: " << account_server
             << ", hostname_suffix: " << hostname_suffix
-            << ", premium_only: " << premium_only << std::endl;
+            << ", premium_only: " << premium_only
+            << ", observability_project: " << observability_project
+            << std::endl;
+  if (!observability_project.empty()) {
+    grpc::RegisterOpenCensusPlugin();
+    grpc::RegisterOpenCensusViewsForExport();
+    opencensus::trace::TraceConfig::SetCurrentTraceParams(
+        {128, 128, 128, 128, opencensus::trace::ProbabilitySampler(1.0)});
+    opencensus::exporters::trace::StackdriverOptions trace_opts;
+    trace_opts.project_id = observability_project;
+    opencensus::exporters::trace::StackdriverExporter::Register(
+      std::move(trace_opts));
+    opencensus::exporters::stats::StackdriverOptions stats_opts;
+    stats_opts.project_id = observability_project;
+    opencensus::exporters::stats::StackdriverExporter::Register(
+        std::move(stats_opts));
+  }
   RunServer(port, account_server, hostname_suffix, premium_only);
   return 0;
 }

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -16,15 +16,15 @@
  *
  */
 
-#include <unistd.h>
-#include <iostream>
-#include <memory>
-#include <string>
-
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/opencensus.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
 
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
@@ -32,10 +32,6 @@
 #include "proto/grpc/examples/wallet/stats/stats.grpc.pb.h"
 #include "proto/grpc/examples/wallet/wallet.grpc.pb.h"
 
-using grpc::examples::wallet::account::Account;
-using grpc::examples::wallet::account::GetUserInfoRequest;
-using grpc::examples::wallet::account::GetUserInfoResponse;
-using grpc::examples::wallet::account::MembershipType;
 using grpc::Channel;
 using grpc::ChannelArguments;
 using grpc::ClientContext;
@@ -46,12 +42,16 @@ using grpc::ServerContext;
 using grpc::ServerWriter;
 using grpc::Status;
 using grpc::StatusCode;
-using grpc::examples::wallet::stats::PriceRequest;
-using grpc::examples::wallet::stats::PriceResponse;
-using grpc::examples::wallet::stats::Stats;
 using grpc::examples::wallet::BalanceRequest;
 using grpc::examples::wallet::BalanceResponse;
 using grpc::examples::wallet::Wallet;
+using grpc::examples::wallet::account::Account;
+using grpc::examples::wallet::account::GetUserInfoRequest;
+using grpc::examples::wallet::account::GetUserInfoResponse;
+using grpc::examples::wallet::account::MembershipType;
+using grpc::examples::wallet::stats::PriceRequest;
+using grpc::examples::wallet::stats::PriceResponse;
+using grpc::examples::wallet::stats::Stats;
 
 class WalletServiceImpl final : public Wallet::Service {
  public:
@@ -351,7 +351,9 @@ int main(int argc, char** argv) {
         observability_project = arg_val.substr(start_pos + 1);
         continue;
       } else {
-        std::cout << "The only correct argument syntax is --observability_project=" << std::endl;
+        std::cout
+            << "The only correct argument syntax is --observability_project="
+            << std::endl;
         return 1;
       }
     }
@@ -371,7 +373,7 @@ int main(int argc, char** argv) {
     opencensus::exporters::trace::StackdriverOptions trace_opts;
     trace_opts.project_id = observability_project;
     opencensus::exporters::trace::StackdriverExporter::Register(
-      std::move(trace_opts));
+        std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
     opencensus::exporters::stats::StackdriverExporter::Register(

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -390,6 +390,8 @@ int main(int argc, char** argv) {
         std::move(trace_opts));
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = observability_project;
+    // This must be unique among all processes exporting to Stackdriver
+    stats_opts.opencensus_task = "wallet-server-" + std::to_string(getpid());
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }


### PR DESCRIPTION
Add C++ metrics and tracing command-line option

~~TODO: C++ server in OSS does not automatically propagate the incoming census context to outbound calls (you can't just use the ServerContext as the ClientContext)~~ Resolved, see https://github.com/census-instrumentation/opencensus-cpp/blob/master/opencensus/doc/context.md#running-under-a-different-context