### PR TITLE
Fix C++ build/update bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,12 @@ http_archive(
     urls = ["https://github.com/googleapis/googleapis/archive/6e3b55e26bf5a9f7874b6ba1411a0cc50cb87a48.zip"],
 )
 
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.2.0/rules_python-0.2.0.tar.gz",
+    sha256 = "778197e26c5fbeb07ac2a2c5ae405b30f6cb7ad1f5510ea6fdac03bded96cc6f",
+)
+
 # Google APIs - used by Stackdriver exporter.
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 

--- a/tools/bazel
+++ b/tools/bazel
@@ -40,7 +40,7 @@ then
   fi
 fi
 
-VERSION=1.0.0
+VERSION=3.7.1
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation." >&2
 
 # update tools/update_mirror.sh to populate the mirror with new bazel archives


### PR DESCRIPTION
Upgrade Bazel from 1.0 to 3.7.1.

This fixes an incompatiblity in our bazel system with the gRPC v1.37 exposed after https://github.com/GoogleCloudPlatform/traffic-director-grpc-examples/pull/20 (there is a master CI build that "caught" this, but it turns out a master CI build whose output is only visible if you explicitly search for it on our internal build UI is not, ahem, as useful as it could be).

The inclusion of the `rules_python` archive in the WORKSPACE file is necessary because...a whack-a-mole sequence of figuring out new errors once I switched to bazel 3.7.1 led to this outcome. The rule itself comes from https://github.com/bazelbuild/rules_python#getting-started.