### PR TITLE
Add admin server to C++/Java/Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out
 target
 
 # Bazel
+tools/bazel-*
 bazel-bin
 bazel-examples
 bazel-genfiles
@@ -36,3 +37,6 @@ bin
 # Emacs
 *~
 \#*\#
+
+# Microsoft VS Code
+.vscode

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,10 +20,10 @@ switched_rules_by_language(
 
 http_archive(
     name = "com_github_grpc_grpc",
+    strip_prefix = "grpc-1.37.0",
     urls = [
         "https://github.com/grpc/grpc/archive/v1.37.0.tar.gz",
     ],
-    strip_prefix = "grpc-1.37.0",
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -11,8 +11,8 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
     ],
 )
 
@@ -27,11 +27,12 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+        "@com_github_grpc_grpc//:grpcpp_admin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
-	      "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
+        "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -45,11 +46,12 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+        "@com_github_grpc_grpc//:grpcpp_admin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
-	      "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
+        "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -62,10 +64,11 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+        "@com_github_grpc_grpc//:grpcpp_admin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
-	      "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
+        "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )

--- a/cpp/account_server.cc
+++ b/cpp/account_server.cc
@@ -95,6 +95,8 @@ void RunServer(const std::string& port, const std::string& hostname_suffix) {
   AccountServiceImpl service(hostname);
   // Listen on the given address without any authentication mechanism.
   std::cout << "Account Server listening on " << server_address << std::endl;
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   // Register "service" as the instance through which we'll communicate with
@@ -186,8 +188,6 @@ int main(int argc, char** argv) {
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }
-  grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   auto admin_server = StartAdminServer(admin_port);
   RunServer(port, hostname_suffix);
   return 0;

--- a/cpp/account_server.cc
+++ b/cpp/account_server.cc
@@ -109,7 +109,7 @@ void RunServer(const std::string& port, const std::string& hostname_suffix) {
 
 int main(int argc, char** argv) {
   std::string port = "18883";
-  std::string admin_port = "58883";
+  std::string admin_port = "28883";
   std::string hostname_suffix = "";
   std::string observability_project = "";
   std::string arg_str_port("--port");

--- a/cpp/stats_server.cc
+++ b/cpp/stats_server.cc
@@ -211,7 +211,7 @@ void RunServer(const std::string& port, const std::string& account_server,
 
 int main(int argc, char** argv) {
   std::string port = "18882";
-  std::string admin_port = "58882";
+  std::string admin_port = "28882";
   std::string account_server = "localhost:18883";
   std::string hostname_suffix = "";
   bool premium_only = false;

--- a/cpp/stats_server.cc
+++ b/cpp/stats_server.cc
@@ -197,6 +197,8 @@ void RunServer(const std::string& port, const std::string& account_server,
       account_server, grpc::InsecureChannelCredentials(), args)));
   // Listen on the given address without any authentication mechanism.
   std::cout << "Stats Server listening on " << server_address << std::endl;
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   // Register "service" as the instance through which we'll communicate with
@@ -328,8 +330,6 @@ int main(int argc, char** argv) {
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }
-  grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   auto admin_server = StartAdminServer(admin_port);
   RunServer(port, account_server, hostname_suffix, premium_only);
   return 0;

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -284,7 +284,7 @@ void RunServer(const std::string& port, const std::string& account_server,
 
 int main(int argc, char** argv) {
   std::string port = "18881";
-  std::string admin_port = "58881";
+  std::string admin_port = "28881";
   std::string account_server = "localhost:18882";
   std::string stats_server = "localhost:18883";
   std::string hostname_suffix = "";

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -16,6 +16,7 @@
  *
  */
 
+#include <grpcpp/ext/admin_services.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -237,6 +238,15 @@ class WalletServiceImpl final : public Wallet::Service {
       {"Bob", {{"148de9c5", 271}, {"2e7d2c03", 828}}}};
 };
 
+std::unique_ptr<Server> StartAdminServer(const std::string& port) {
+  std::string server_address = "localhost" + port;
+  std::cout << "Admin Server listening on " << server_address << std::endl;
+  ServerBuilder builder;
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  grpc::AddAdminServices(&builder);
+  return builder.BuildAndStart();
+}
+
 void RunServer(const std::string& port, const std::string& account_server,
                const std::string& stats_server,
                const std::string& hostname_suffix, const bool v1_behavior) {
@@ -249,8 +259,6 @@ void RunServer(const std::string& port, const std::string& account_server,
   std::string server_address("0.0.0.0:");
   server_address += port;
   WalletServiceImpl service(hostname, v1_behavior);
-  grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   // Instantiate the client stubs.  It requires a channel, out of which the
   // actual RPCs are created.  The channel models a connection to an endpoint
   // (Stats Server and Account Server in this case).  We indicate that the
@@ -276,12 +284,14 @@ void RunServer(const std::string& port, const std::string& account_server,
 
 int main(int argc, char** argv) {
   std::string port = "18881";
+  std::string admin_port = "58881";
   std::string account_server = "localhost:18882";
   std::string stats_server = "localhost:18883";
   std::string hostname_suffix = "";
   bool v1_behavior = false;
   std::string observability_project = "";
   std::string arg_str_port("--port");
+  std::string arg_str_admin_port("--admin_port");
   std::string arg_str_account_server("--account_server");
   std::string arg_str_stats_server("--stats_server");
   std::string arg_str_hostname_suffix("--hostname_suffix");
@@ -297,6 +307,17 @@ int main(int argc, char** argv) {
         continue;
       } else {
         std::cout << "The only correct argument syntax is --port=" << std::endl;
+        return 1;
+      }
+    }
+    start_pos = arg_val.find(arg_str_admin_port);
+    if (start_pos != std::string::npos) {
+      start_pos += arg_str_admin_port.size();
+      if (arg_val[start_pos] == '=') {
+        admin_port = arg_val.substr(start_pos + 1);
+        continue;
+      } else {
+        std::cout << "The only correct argument syntax is --admin_port=" << std::endl;
         return 1;
       }
     }
@@ -395,6 +416,9 @@ int main(int argc, char** argv) {
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  auto admin_server = StartAdminServer(admin_port);
   RunServer(port, account_server, stats_server, hostname_suffix, v1_behavior);
   return 0;
 }

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -270,6 +270,8 @@ void RunServer(const std::string& port, const std::string& account_server,
       account_server, grpc::InsecureChannelCredentials(), args)));
   // Listen on the given address without any authentication mechanism.
   std::cout << "Wallet server listening on " << server_address << std::endl;
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   // Register "service" as the instance through which we'll communicate with
@@ -416,8 +418,6 @@ int main(int argc, char** argv) {
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }
-  grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   auto admin_server = StartAdminServer(admin_port);
   RunServer(port, account_server, stats_server, hostname_suffix, v1_behavior);
   return 0;

--- a/go/account_server/main.go
+++ b/go/account_server/main.go
@@ -101,7 +101,7 @@ func main() {
 	}
 
 	// Start admin server
-	adminListener, err := net.Listen("tcp", ":"+args.port)
+	adminListener, err := net.Listen("tcp", "localhost:"+args.adminPort)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/go/account_server/main.go
+++ b/go/account_server/main.go
@@ -61,7 +61,7 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18883", "the port to listen on, default '18883'")
-	flag.StringVar(&result.adminPort, "admin_port", "58883", "the admin port to listen on, default '58883'")
+	flag.StringVar(&result.adminPort, "admin_port", "28883", "the admin port to listen on, default '28883'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")
 	flag.StringVar(&result.observabilityProject, "observability_project", "", "if set, metrics and traces will be sent to Cloud Monitoring and Cloud Trace")
 	flag.Parse()

--- a/go/account_server/main.go
+++ b/go/account_server/main.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/admin"
 	"google.golang.org/grpc/codes"
 	accountpb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet/account"
 	"google.golang.org/grpc/grpc-wallet/observability"
@@ -51,6 +52,7 @@ var users = map[string]user{
 
 type arguments struct {
 	port                 string
+	adminPort            string
 	hostnameSuffix       string
 	observabilityProject string
 }
@@ -59,6 +61,7 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18883", "the port to listen on, default '18883'")
+	flag.StringVar(&result.adminPort, "admin_port", "58883", "the admin port to listen on, default '58883'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")
 	flag.StringVar(&result.observabilityProject, "observability_project", "", "if set, metrics and traces will be sent to Cloud Monitoring and Cloud Trace")
 	flag.Parse()
@@ -96,6 +99,20 @@ func main() {
 		defer sd.StopMetricsExporter()
 		serverOpts = append(serverOpts, grpc.StatsHandler(&ocgrpc.ServerHandler{}))
 	}
+
+	// Start admin server
+	adminListener, err := net.Listen("tcp", ":"+args.port)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	adminServer := grpc.NewServer()
+	cleanup, err := admin.Register(adminServer)
+	if err != nil {
+		log.Fatalf("failed to register admin: %v", err)
+	}
+	defer cleanup()
+	go adminServer.Serve(adminListener)
+	defer adminServer.Stop()
 
 	lis, err := net.Listen("tcp", ":"+args.port)
 	if err != nil {

--- a/go/stats_server/main.go
+++ b/go/stats_server/main.go
@@ -28,6 +28,7 @@ import (
 
 	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/admin"
 	"google.golang.org/grpc/codes"
 	accountpb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet/account"
 	statspb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet/stats"
@@ -44,6 +45,7 @@ import (
 
 type arguments struct {
 	port                 string
+	adminPort            string
 	accountServer        string
 	hostnameSuffix       string
 	premiumOnly          bool
@@ -54,6 +56,7 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18882", "the port to listen on, default '18882'")
+	flag.StringVar(&result.adminPort, "admin_port", "58882", "the admin port to listen on, default '58882'")
 	flag.StringVar(&result.accountServer, "account_server", "localhost:18883", "address of the account service, default 'localhost:18883'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")
 	flag.BoolVar(&result.premiumOnly, "premium_only", false, "whether this service is for users with premium access only, default false")
@@ -151,6 +154,20 @@ func main() {
 	}
 	defer conn.Close()
 	c := accountpb.NewAccountClient(conn)
+
+	// Start admin server
+	adminListener, err := net.Listen("tcp", ":"+args.port)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	adminServer := grpc.NewServer()
+	cleanup, err := admin.Register(adminServer)
+	if err != nil {
+		log.Fatalf("failed to register admin: %v", err)
+	}
+	defer cleanup()
+	go adminServer.Serve(adminListener)
+	defer adminServer.Stop()
 
 	// Listen & serve.
 	lis, err := net.Listen("tcp", ":"+args.port)

--- a/go/stats_server/main.go
+++ b/go/stats_server/main.go
@@ -156,7 +156,7 @@ func main() {
 	c := accountpb.NewAccountClient(conn)
 
 	// Start admin server
-	adminListener, err := net.Listen("tcp", ":"+args.port)
+	adminListener, err := net.Listen("tcp", "localhost:"+args.adminPort)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/go/stats_server/main.go
+++ b/go/stats_server/main.go
@@ -56,7 +56,7 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18882", "the port to listen on, default '18882'")
-	flag.StringVar(&result.adminPort, "admin_port", "58882", "the admin port to listen on, default '58882'")
+	flag.StringVar(&result.adminPort, "admin_port", "28882", "the admin port to listen on, default '28882'")
 	flag.StringVar(&result.accountServer, "account_server", "localhost:18883", "address of the account service, default 'localhost:18883'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")
 	flag.BoolVar(&result.premiumOnly, "premium_only", false, "whether this service is for users with premium access only, default false")

--- a/go/wallet_server/main.go
+++ b/go/wallet_server/main.go
@@ -211,7 +211,7 @@ func main() {
 	statsClient := statspb.NewStatsClient(statsConn)
 
 	// Start admin server
-	adminListener, err := net.Listen("tcp", ":"+args.port)
+	adminListener, err := net.Listen("tcp", "localhost:"+args.adminPort)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/go/wallet_server/main.go
+++ b/go/wallet_server/main.go
@@ -68,7 +68,7 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18881", "the port to listen on, default '18881'")
-	flag.StringVar(&result.adminPort, "admin_port", "58881", "the admin port to listen on, default '58881'")
+	flag.StringVar(&result.adminPort, "admin_port", "28881", "the admin port to listen on, default '28881'")
 	flag.StringVar(&result.accountServer, "account_server", "localhost:18883", "address of the account service, default 'localhost:18883'")
 	flag.StringVar(&result.statsServer, "stats_server", "localhost:18882", "address of the stats service, default 'localhost:18882'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")

--- a/go/wallet_server/main.go
+++ b/go/wallet_server/main.go
@@ -27,6 +27,7 @@ import (
 
 	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/admin"
 	"google.golang.org/grpc/codes"
 	walletpb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet"
 	accountpb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet/account"
@@ -55,6 +56,7 @@ var users = map[string]map[string]int{
 
 type arguments struct {
 	port                 string
+	adminPort            string
 	accountServer        string
 	statsServer          string
 	hostnameSuffix       string
@@ -66,6 +68,7 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18881", "the port to listen on, default '18881'")
+	flag.StringVar(&result.adminPort, "admin_port", "58881", "the admin port to listen on, default '58881'")
 	flag.StringVar(&result.accountServer, "account_server", "localhost:18883", "address of the account service, default 'localhost:18883'")
 	flag.StringVar(&result.statsServer, "stats_server", "localhost:18882", "address of the stats service, default 'localhost:18882'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")
@@ -206,6 +209,20 @@ func main() {
 	}
 	defer statsConn.Close()
 	statsClient := statspb.NewStatsClient(statsConn)
+
+	// Start admin server
+	adminListener, err := net.Listen("tcp", ":"+args.port)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	adminServer := grpc.NewServer()
+	cleanup, err := admin.Register(adminServer)
+	if err != nil {
+		log.Fatalf("failed to register admin: %v", err)
+	}
+	defer cleanup()
+	go adminServer.Serve(adminListener)
+	defer adminServer.Stop()
 
 	// Listen & serve.
 	lis, err := net.Listen("tcp", ":"+args.port)

--- a/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
+import io.grpc.services.AdminInterface;
 import io.grpc.Status;
 import io.grpc.examples.wallet.account.AccountGrpc;
 import io.grpc.examples.wallet.account.GetUserInfoRequest;
@@ -38,8 +39,10 @@ public class AccountServer {
   private static final Logger logger = Logger.getLogger(AccountServer.class.getName());
 
   private Server server;
+  private Server adminServer;
 
   private int port = 18883;
+  private int adminPort = 58883;
   private String hostnameSuffix = "";
   private String observabilityProject = "";
 
@@ -65,6 +68,8 @@ public class AccountServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port = Integer.parseInt(value);
+      } else if ("admin_port".equals(key)) {
+        adminPort = Integer.parseInt(value);
       } else if ("hostname_suffix".equals(key)) {
         hostnameSuffix = value;
       } else if ("observability_project".equals(key)) {
@@ -82,6 +87,8 @@ public class AccountServer {
               + "\n"
               + "\n  --port=PORT            The port to listen on. Default "
               + s.port
+              + "\n  --admin_port=PORT      The admin port to listen on. Default "
+              + s.adminPort
               + "\n  --hostname_suffix=STR  Suffix to append to hostname in response header. "
               + "Default \""
               + s.hostnameSuffix
@@ -96,6 +103,10 @@ public class AccountServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
+    adminServer = ServerBuilder.forPort(adminPort)
+        .addServices(AdminInterface.getStandardServices())
+        .build()
+        .start();
     HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)

--- a/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
@@ -103,14 +103,12 @@ public class AccountServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
-    HealthStatusManager health = new HealthStatusManager();
     adminServer = ServerBuilder.forPort(adminPort)
-        .addService(ProtoReflectionService.newInstance())
-        .addService(health.getHealthService())
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
     logger.info("Admin server started, listening on " + adminPort);
+    HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)
             .addService(

--- a/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
@@ -107,6 +107,7 @@ public class AccountServer {
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
+    logger.info("Admin server started, listening on " + adminPort);
     HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)

--- a/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
@@ -42,7 +42,7 @@ public class AccountServer {
   private Server adminServer;
 
   private int port = 18883;
-  private int adminPort = 58883;
+  private int adminPort = 28883;
   private String hostnameSuffix = "";
   private String observabilityProject = "";
 
@@ -103,12 +103,14 @@ public class AccountServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
+    HealthStatusManager health = new HealthStatusManager();
     adminServer = ServerBuilder.forPort(adminPort)
+        .addService(ProtoReflectionService.newInstance())
+        .addService(health.getHealthService())
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
     logger.info("Admin server started, listening on " + adminPort);
-    HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)
             .addService(

--- a/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
@@ -139,6 +139,9 @@ public class AccountServer {
     if (server != null) {
       server.shutdown().awaitTermination(30, SECONDS);
     }
+    if (adminServer != null) {
+      adminServer.shutdown().awaitTermination(30, SECONDS);
+    }
   }
 
   private void blockUntilShutdown() throws InterruptedException {

--- a/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
@@ -130,16 +130,14 @@ public class StatsServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
-    HealthStatusManager health = new HealthStatusManager();
     adminServer = ServerBuilder.forPort(adminPort)
-        .addService(ProtoReflectionService.newInstance())
-        .addService(health.getHealthService())
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
     logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     exec = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
+    HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)
             .addService(

--- a/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
@@ -27,6 +27,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
+import io.grpc.services.AdminInterface;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.wallet.account.AccountGrpc;
@@ -51,8 +52,10 @@ public class StatsServer {
   private static final Logger logger = Logger.getLogger(StatsServer.class.getName());
 
   private Server server;
+  private Server adminServer;
 
   private int port = 18882;
+  private int adminPort = 58882;
   private String accountServer = "localhost:18883";
   private String hostnameSuffix = "";
   private String observabilityProject = "";
@@ -83,6 +86,8 @@ public class StatsServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port = Integer.parseInt(value);
+      } else if ("admin_port".equals(key)) {
+        adminPort = Integer.parseInt(value);
       } else if ("account_server".equals(key)) {
         accountServer = value;
       } else if ("hostname_suffix".equals(key)) {
@@ -104,6 +109,8 @@ public class StatsServer {
               + "\n"
               + "\n  --port=PORT                The port to listen on. Default "
               + s.port
+              + "\n  --admin_port=PORT      The admin port to listen on. Default "
+              + s.adminPort
               + "\n  --account_server=HOST      Address of the account server. Default "
               + s.accountServer
               + "\n  --hostname_suffix=STR      Suffix to append to hostname in response header. "
@@ -123,6 +130,10 @@ public class StatsServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
+    adminServer = ServerBuilder.forPort(adminPort)
+        .addServices(AdminInterface.getStandardServices())
+        .build()
+        .start();
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     exec = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
     HealthStatusManager health = new HealthStatusManager();

--- a/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
@@ -134,6 +134,7 @@ public class StatsServer {
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
+    logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     exec = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
     HealthStatusManager health = new HealthStatusManager();

--- a/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
@@ -55,7 +55,7 @@ public class StatsServer {
   private Server adminServer;
 
   private int port = 18882;
-  private int adminPort = 58882;
+  private int adminPort = 28882;
   private String accountServer = "localhost:18883";
   private String hostnameSuffix = "";
   private String observabilityProject = "";
@@ -130,14 +130,16 @@ public class StatsServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
+    HealthStatusManager health = new HealthStatusManager();
     adminServer = ServerBuilder.forPort(adminPort)
+        .addService(ProtoReflectionService.newInstance())
+        .addService(health.getHealthService())
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
     logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     exec = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
-    HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)
             .addService(

--- a/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
@@ -109,7 +109,7 @@ public class StatsServer {
               + "\n"
               + "\n  --port=PORT                The port to listen on. Default "
               + s.port
-              + "\n  --admin_port=PORT      The admin port to listen on. Default "
+              + "\n  --admin_port=PORT          The admin port to listen on. Default "
               + s.adminPort
               + "\n  --account_server=HOST      Address of the account server. Default "
               + s.accountServer
@@ -169,6 +169,9 @@ public class StatsServer {
   private void stop() throws InterruptedException {
     if (server != null) {
       server.shutdown().awaitTermination(30, SECONDS);
+    }
+    if (adminServer != null) {
+      adminServer.shutdown().awaitTermination(30, SECONDS);
     }
     if (accountChannel != null) {
       accountChannel.shutdownNow().awaitTermination(5, SECONDS);

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -110,7 +110,7 @@ public class WalletServer {
               + "\n"
               + "\n  --port=PORT                The port to listen on. Default "
               + s.port
-              + "\n  --admin_port=PORT      The admin port to listen on. Default "
+              + "\n  --admin_port=PORT          The admin port to listen on. Default "
               + s.adminPort
               + "\n  --account_server=HOST      Address of the account server. Default "
               + s.accountServer
@@ -172,6 +172,9 @@ public class WalletServer {
   private void stop() throws InterruptedException {
     if (server != null) {
       server.shutdown().awaitTermination(30, SECONDS);
+    }
+    if (adminServer != null) {
+      adminServer.shutdown().awaitTermination(30, SECONDS);
     }
     if (accountChannel != null) {
       accountChannel.shutdownNow().awaitTermination(5, SECONDS);

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -53,7 +53,7 @@ public class WalletServer {
   private Server server;
   private Server adminServer;
   private int port = 18881;
-  private int adminPort = 58881;
+  private int adminPort = 28881;
   private String accountServer = "localhost:18883";
   private String statsServer = "localhost:18882";
   private String hostnameSuffix = "";
@@ -133,14 +133,16 @@ public class WalletServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
+    HealthStatusManager health = new HealthStatusManager();
     adminServer = ServerBuilder.forPort(adminPort)
+        .addService(ProtoReflectionService.newInstance())
+        .addService(health.getHealthService())
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
     logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     statsChannel = ManagedChannelBuilder.forTarget(statsServer).usePlaintext().build();
-    HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)
             .addService(

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -137,6 +137,7 @@ public class WalletServer {
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
+    logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     statsChannel = ManagedChannelBuilder.forTarget(statsServer).usePlaintext().build();
     HealthStatusManager health = new HealthStatusManager();

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -133,16 +133,14 @@ public class WalletServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
-    HealthStatusManager health = new HealthStatusManager();
     adminServer = ServerBuilder.forPort(adminPort)
-        .addService(ProtoReflectionService.newInstance())
-        .addService(health.getHealthService())
         .addServices(AdminInterface.getStandardServices())
         .build()
         .start();
     logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     statsChannel = ManagedChannelBuilder.forTarget(statsServer).usePlaintext().build();
+    HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)
             .addService(

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -23,6 +23,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Server;
+import io.grpc.services.AdminInterface;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
@@ -50,7 +51,9 @@ public class WalletServer {
   private static final Logger logger = Logger.getLogger(WalletServer.class.getName());
 
   private Server server;
+  private Server adminServer;
   private int port = 18881;
+  private int adminPort = 58881;
   private String accountServer = "localhost:18883";
   private String statsServer = "localhost:18882";
   private String hostnameSuffix = "";
@@ -82,6 +85,8 @@ public class WalletServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port = Integer.parseInt(value);
+      } else if ("admin_port".equals(key)) {
+        adminPort = Integer.parseInt(value);
       } else if ("account_server".equals(key)) {
         accountServer = value;
       } else if ("stats_server".equals(key)) {
@@ -105,6 +110,8 @@ public class WalletServer {
               + "\n"
               + "\n  --port=PORT                The port to listen on. Default "
               + s.port
+              + "\n  --admin_port=PORT      The admin port to listen on. Default "
+              + s.adminPort
               + "\n  --account_server=HOST      Address of the account server. Default "
               + s.accountServer
               + "\n  --stats_server=HOST        Address of the stats server. Default "
@@ -126,6 +133,10 @@ public class WalletServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
+    adminServer = ServerBuilder.forPort(adminPort)
+        .addServices(AdminInterface.getStandardServices())
+        .build()
+        .start();
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     statsChannel = ManagedChannelBuilder.forTarget(statsServer).usePlaintext().build();
     HealthStatusManager health = new HealthStatusManager();


### PR DESCRIPTION
This PR adds an admin server to all Account, Stats, and Wallet examples in C++/Java/Go. The admin port can be controlled unanimously via the flag `--admin_port=<int>`. By default, the admin port for Wallet is `localhost:58881`, for Stats is `localhost:58882`, and for Account is `localhost:58883`.

The Golang changes are manually tested in GCP. And used to produce snippets in our Observability user guide.

Also, I'm experiencing some trouble with setting up admin server in Java. It compiles, but yielding no Channelz or CSDS information. @sergiitk Please help.

How do we test the code? What's the norm?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/traffic-director-grpc-examples/22)
<!-- Reviewable:end -->
