### PR TITLE
Fix C++ Bazel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out
 target
 
 # Bazel
+tools/bazel-*
 bazel-bin
 bazel-examples
 bazel-genfiles

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,9 +27,9 @@ http_archive(
 
 http_archive(
     name = "com_github_grpc_grpc",
-    strip_prefix = "grpc-1.37.0",
+    strip_prefix = "grpc-1.36.0",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.37.0.tar.gz",
+        "https://github.com/grpc/grpc/archive/v1.36.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,12 +18,19 @@ switched_rules_by_language(
     grpc = True,
 )
 
+# @rules_python//python:defs.bzl is required by @com_google_protobuf
+http_archive(
+    name = "rules_python",
+    sha256 = "778197e26c5fbeb07ac2a2c5ae405b30f6cb7ad1f5510ea6fdac03bded96cc6f",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.2.0/rules_python-0.2.0.tar.gz",
+)
+
 http_archive(
     name = "com_github_grpc_grpc",
+    strip_prefix = "grpc-1.37.0",
     urls = [
         "https://github.com/grpc/grpc/archive/v1.37.0.tar.gz",
     ],
-    strip_prefix = "grpc-1.37.0",
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -11,8 +11,8 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
     ],
 )
 
@@ -29,9 +29,9 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
-	      "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
+        "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -47,9 +47,9 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
-	      "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
+        "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -64,8 +64,8 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats:stats",
-	      "@io_opencensus_cpp//opencensus/trace:trace",
-	      "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/trace",
+        "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )

--- a/tools/bazel
+++ b/tools/bazel
@@ -40,7 +40,7 @@ then
   fi
 fi
 
-VERSION=1.0.0
+VERSION=3.7.1
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation." >&2
 
 # update tools/update_mirror.sh to populate the mirror with new bazel archives


### PR DESCRIPTION
Test run: [sponge/bcffeaae-6888-4181-86ad-8f7b65d3d9df](http://sponge/bcffeaae-6888-4181-86ad-8f7b65d3d9df)

gRPC Core's essential dependency `upb` has checked-in code that requires Bazel >3.4 (see [code](https://github.com/protocolbuffers/upb/blob/master/bazel/upb_proto_library.bzl#L369)). So, this PR bumped the Bazel version to align with gRPC main repo.

Also, it fixed other Bazel dependency issues. Let's see if tests are happy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/traffic-director-grpc-examples/23)
<!-- Reviewable:end -->
