### PR TITLE
Revert "Add admin server to C++/Java/Go"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ out
 target
 
 # Bazel
-tools/bazel-*
 bazel-bin
 bazel-examples
 bazel-genfiles
@@ -37,6 +36,3 @@ bin
 # Emacs
 *~
 \#*\#
-
-# Microsoft VS Code
-.vscode

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,10 +26,10 @@ switched_rules_by_language(
 
 http_archive(
     name = "com_github_grpc_grpc",
-    strip_prefix = "grpc-1.37.0",
     urls = [
         "https://github.com/grpc/grpc/archive/v1.37.0.tar.gz",
     ],
+    strip_prefix = "grpc-1.37.0",
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -11,8 +11,8 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats",
-        "@io_opencensus_cpp//opencensus/trace",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
     ],
 )
 
@@ -27,12 +27,11 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
-        "@com_github_grpc_grpc//:grpcpp_admin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats",
-        "@io_opencensus_cpp//opencensus/trace",
-        "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
+	      "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -46,12 +45,11 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
-        "@com_github_grpc_grpc//:grpcpp_admin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats",
-        "@io_opencensus_cpp//opencensus/trace",
-        "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
+	      "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )
 
@@ -64,11 +62,10 @@ cc_binary(
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_grpc_grpc//:grpc_opencensus_plugin",
-        "@com_github_grpc_grpc//:grpcpp_admin",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-        "@io_opencensus_cpp//opencensus/stats",
-        "@io_opencensus_cpp//opencensus/trace",
-        "@io_opencensus_cpp//opencensus/trace:with_span",
+        "@io_opencensus_cpp//opencensus/stats:stats",
+	      "@io_opencensus_cpp//opencensus/trace:trace",
+	      "@io_opencensus_cpp//opencensus/trace:with_span",
     ],
 )

--- a/cpp/account_server.cc
+++ b/cpp/account_server.cc
@@ -16,7 +16,6 @@
  *
  */
 
-#include <grpcpp/ext/admin_services.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -73,15 +72,6 @@ class AccountServiceImpl final : public Account::Service {
   std::string hostname_;
 };
 
-std::unique_ptr<Server> StartAdminServer(const std::string& port) {
-  std::string server_address = "localhost" + port;
-  std::cout << "Admin Server listening on " << server_address << std::endl;
-  ServerBuilder builder;
-  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  grpc::AddAdminServices(&builder);
-  return builder.BuildAndStart();
-}
-
 void RunServer(const std::string& port, const std::string& hostname_suffix) {
   std::string hostname;
   char base_hostname[256];
@@ -93,10 +83,10 @@ void RunServer(const std::string& port, const std::string& hostname_suffix) {
   std::string server_address("0.0.0.0:");
   server_address += port;
   AccountServiceImpl service(hostname);
-  // Listen on the given address without any authentication mechanism.
-  std::cout << "Account Server listening on " << server_address << std::endl;
   grpc::EnableDefaultHealthCheckService(true);
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  // Listen on the given address without any authentication mechanism.
+  std::cout << "Account Server listening on " << server_address << std::endl;
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   // Register "service" as the instance through which we'll communicate with
@@ -111,11 +101,9 @@ void RunServer(const std::string& port, const std::string& hostname_suffix) {
 
 int main(int argc, char** argv) {
   std::string port = "18883";
-  std::string admin_port = "28883";
   std::string hostname_suffix = "";
   std::string observability_project = "";
   std::string arg_str_port("--port");
-  std::string arg_str_admin_port("--admin_port");
   std::string arg_str_hostname_suffix("--hostname_suffix");
   std::string arg_str_observability_project("--observability_project");
   for (int i = 1; i < argc; ++i) {
@@ -128,17 +116,6 @@ int main(int argc, char** argv) {
         continue;
       } else {
         std::cout << "The only correct argument syntax is --port=" << std::endl;
-        return 1;
-      }
-    }
-    start_pos = arg_val.find(arg_str_admin_port);
-    if (start_pos != std::string::npos) {
-      start_pos += arg_str_admin_port.size();
-      if (arg_val[start_pos] == '=') {
-        admin_port = arg_val.substr(start_pos + 1);
-        continue;
-      } else {
-        std::cout << "The only correct argument syntax is --admin_port=" << std::endl;
         return 1;
       }
     }
@@ -188,7 +165,6 @@ int main(int argc, char** argv) {
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }
-  auto admin_server = StartAdminServer(admin_port);
   RunServer(port, hostname_suffix);
   return 0;
 }

--- a/cpp/stats_server.cc
+++ b/cpp/stats_server.cc
@@ -16,7 +16,6 @@
  *
  */
 
-#include <grpcpp/ext/admin_services.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -168,15 +167,6 @@ class StatsServiceImpl final : public Stats::Service {
   std::string membership_ = "premium";
 };
 
-std::unique_ptr<Server> StartAdminServer(const std::string& port) {
-  std::string server_address = "localhost" + port;
-  std::cout << "Admin Server listening on " << server_address << std::endl;
-  ServerBuilder builder;
-  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  grpc::AddAdminServices(&builder);
-  return builder.BuildAndStart();
-}
-
 void RunServer(const std::string& port, const std::string& account_server,
                const std::string& hostname_suffix, const bool premium_only) {
   char base_hostname[256];
@@ -188,6 +178,8 @@ void RunServer(const std::string& port, const std::string& account_server,
   std::string server_address("0.0.0.0:");
   server_address += port;
   StatsServiceImpl service(hostname, premium_only);
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   // Instantiate the client stub.  It requires a channel, out of which the
   // actual RPCs are created.  The channel models a connection to an endpoint
   // (Account Server in this case).  We indicate that the channel isn't
@@ -197,8 +189,6 @@ void RunServer(const std::string& port, const std::string& account_server,
       account_server, grpc::InsecureChannelCredentials(), args)));
   // Listen on the given address without any authentication mechanism.
   std::cout << "Stats Server listening on " << server_address << std::endl;
-  grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   // Register "service" as the instance through which we'll communicate with
@@ -213,13 +203,11 @@ void RunServer(const std::string& port, const std::string& account_server,
 
 int main(int argc, char** argv) {
   std::string port = "18882";
-  std::string admin_port = "28882";
   std::string account_server = "localhost:18883";
   std::string hostname_suffix = "";
   bool premium_only = false;
   std::string observability_project = "";
   std::string arg_str_port("--port");
-  std::string arg_str_admin_port("--admin_port");
   std::string arg_str_account_server("--account_server");
   std::string arg_str_hostname_suffix("--hostname_suffix");
   std::string arg_str_premium_only("--premium_only");
@@ -234,17 +222,6 @@ int main(int argc, char** argv) {
         continue;
       } else {
         std::cout << "The only correct argument syntax is --port=" << std::endl;
-        return 1;
-      }
-    }
-    start_pos = arg_val.find(arg_str_admin_port);
-    if (start_pos != std::string::npos) {
-      start_pos += arg_str_admin_port.size();
-      if (arg_val[start_pos] == '=') {
-        admin_port = arg_val.substr(start_pos + 1);
-        continue;
-      } else {
-        std::cout << "The only correct argument syntax is --admin_port=" << std::endl;
         return 1;
       }
     }
@@ -330,7 +307,6 @@ int main(int argc, char** argv) {
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }
-  auto admin_server = StartAdminServer(admin_port);
   RunServer(port, account_server, hostname_suffix, premium_only);
   return 0;
 }

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -16,7 +16,6 @@
  *
  */
 
-#include <grpcpp/ext/admin_services.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -238,15 +237,6 @@ class WalletServiceImpl final : public Wallet::Service {
       {"Bob", {{"148de9c5", 271}, {"2e7d2c03", 828}}}};
 };
 
-std::unique_ptr<Server> StartAdminServer(const std::string& port) {
-  std::string server_address = "localhost" + port;
-  std::cout << "Admin Server listening on " << server_address << std::endl;
-  ServerBuilder builder;
-  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  grpc::AddAdminServices(&builder);
-  return builder.BuildAndStart();
-}
-
 void RunServer(const std::string& port, const std::string& account_server,
                const std::string& stats_server,
                const std::string& hostname_suffix, const bool v1_behavior) {
@@ -259,6 +249,8 @@ void RunServer(const std::string& port, const std::string& account_server,
   std::string server_address("0.0.0.0:");
   server_address += port;
   WalletServiceImpl service(hostname, v1_behavior);
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   // Instantiate the client stubs.  It requires a channel, out of which the
   // actual RPCs are created.  The channel models a connection to an endpoint
   // (Stats Server and Account Server in this case).  We indicate that the
@@ -270,8 +262,6 @@ void RunServer(const std::string& port, const std::string& account_server,
       account_server, grpc::InsecureChannelCredentials(), args)));
   // Listen on the given address without any authentication mechanism.
   std::cout << "Wallet server listening on " << server_address << std::endl;
-  grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   // Register "service" as the instance through which we'll communicate with
@@ -286,14 +276,12 @@ void RunServer(const std::string& port, const std::string& account_server,
 
 int main(int argc, char** argv) {
   std::string port = "18881";
-  std::string admin_port = "28881";
   std::string account_server = "localhost:18882";
   std::string stats_server = "localhost:18883";
   std::string hostname_suffix = "";
   bool v1_behavior = false;
   std::string observability_project = "";
   std::string arg_str_port("--port");
-  std::string arg_str_admin_port("--admin_port");
   std::string arg_str_account_server("--account_server");
   std::string arg_str_stats_server("--stats_server");
   std::string arg_str_hostname_suffix("--hostname_suffix");
@@ -309,17 +297,6 @@ int main(int argc, char** argv) {
         continue;
       } else {
         std::cout << "The only correct argument syntax is --port=" << std::endl;
-        return 1;
-      }
-    }
-    start_pos = arg_val.find(arg_str_admin_port);
-    if (start_pos != std::string::npos) {
-      start_pos += arg_str_admin_port.size();
-      if (arg_val[start_pos] == '=') {
-        admin_port = arg_val.substr(start_pos + 1);
-        continue;
-      } else {
-        std::cout << "The only correct argument syntax is --admin_port=" << std::endl;
         return 1;
       }
     }
@@ -418,7 +395,6 @@ int main(int argc, char** argv) {
     opencensus::exporters::stats::StackdriverExporter::Register(
         std::move(stats_opts));
   }
-  auto admin_server = StartAdminServer(admin_port);
   RunServer(port, account_server, stats_server, hostname_suffix, v1_behavior);
   return 0;
 }

--- a/go/account_server/main.go
+++ b/go/account_server/main.go
@@ -26,7 +26,6 @@ import (
 
 	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/admin"
 	"google.golang.org/grpc/codes"
 	accountpb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet/account"
 	"google.golang.org/grpc/grpc-wallet/observability"
@@ -52,7 +51,6 @@ var users = map[string]user{
 
 type arguments struct {
 	port                 string
-	adminPort            string
 	hostnameSuffix       string
 	observabilityProject string
 }
@@ -61,7 +59,6 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18883", "the port to listen on, default '18883'")
-	flag.StringVar(&result.adminPort, "admin_port", "28883", "the admin port to listen on, default '28883'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")
 	flag.StringVar(&result.observabilityProject, "observability_project", "", "if set, metrics and traces will be sent to Cloud Monitoring and Cloud Trace")
 	flag.Parse()
@@ -99,20 +96,6 @@ func main() {
 		defer sd.StopMetricsExporter()
 		serverOpts = append(serverOpts, grpc.StatsHandler(&ocgrpc.ServerHandler{}))
 	}
-
-	// Start admin server
-	adminListener, err := net.Listen("tcp", "localhost:"+args.adminPort)
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
-	adminServer := grpc.NewServer()
-	cleanup, err := admin.Register(adminServer)
-	if err != nil {
-		log.Fatalf("failed to register admin: %v", err)
-	}
-	defer cleanup()
-	go adminServer.Serve(adminListener)
-	defer adminServer.Stop()
 
 	lis, err := net.Listen("tcp", ":"+args.port)
 	if err != nil {

--- a/go/stats_server/main.go
+++ b/go/stats_server/main.go
@@ -28,7 +28,6 @@ import (
 
 	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/admin"
 	"google.golang.org/grpc/codes"
 	accountpb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet/account"
 	statspb "google.golang.org/grpc/grpc-wallet/grpc/examples/wallet/stats"
@@ -45,7 +44,6 @@ import (
 
 type arguments struct {
 	port                 string
-	adminPort            string
 	accountServer        string
 	hostnameSuffix       string
 	premiumOnly          bool
@@ -56,7 +54,6 @@ type arguments struct {
 func parseArguments() arguments {
 	result := arguments{}
 	flag.StringVar(&result.port, "port", "18882", "the port to listen on, default '18882'")
-	flag.StringVar(&result.adminPort, "admin_port", "28882", "the admin port to listen on, default '28882'")
 	flag.StringVar(&result.accountServer, "account_server", "localhost:18883", "address of the account service, default 'localhost:18883'")
 	flag.StringVar(&result.hostnameSuffix, "hostname_suffix", "", "suffix to append to hostname in response header for outgoing RPCs, default ''")
 	flag.BoolVar(&result.premiumOnly, "premium_only", false, "whether this service is for users with premium access only, default false")
@@ -154,20 +151,6 @@ func main() {
 	}
 	defer conn.Close()
 	c := accountpb.NewAccountClient(conn)
-
-	// Start admin server
-	adminListener, err := net.Listen("tcp", "localhost:"+args.adminPort)
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
-	adminServer := grpc.NewServer()
-	cleanup, err := admin.Register(adminServer)
-	if err != nil {
-		log.Fatalf("failed to register admin: %v", err)
-	}
-	defer cleanup()
-	go adminServer.Serve(adminListener)
-	defer adminServer.Stop()
 
 	// Listen & serve.
 	lis, err := net.Listen("tcp", ":"+args.port)

--- a/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/AccountServer.java
@@ -21,7 +21,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
-import io.grpc.services.AdminInterface;
 import io.grpc.Status;
 import io.grpc.examples.wallet.account.AccountGrpc;
 import io.grpc.examples.wallet.account.GetUserInfoRequest;
@@ -39,10 +38,8 @@ public class AccountServer {
   private static final Logger logger = Logger.getLogger(AccountServer.class.getName());
 
   private Server server;
-  private Server adminServer;
 
   private int port = 18883;
-  private int adminPort = 28883;
   private String hostnameSuffix = "";
   private String observabilityProject = "";
 
@@ -68,8 +65,6 @@ public class AccountServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port = Integer.parseInt(value);
-      } else if ("admin_port".equals(key)) {
-        adminPort = Integer.parseInt(value);
       } else if ("hostname_suffix".equals(key)) {
         hostnameSuffix = value;
       } else if ("observability_project".equals(key)) {
@@ -87,8 +82,6 @@ public class AccountServer {
               + "\n"
               + "\n  --port=PORT            The port to listen on. Default "
               + s.port
-              + "\n  --admin_port=PORT      The admin port to listen on. Default "
-              + s.adminPort
               + "\n  --hostname_suffix=STR  Suffix to append to hostname in response header. "
               + "Default \""
               + s.hostnameSuffix
@@ -103,11 +96,6 @@ public class AccountServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
-    adminServer = ServerBuilder.forPort(adminPort)
-        .addServices(AdminInterface.getStandardServices())
-        .build()
-        .start();
-    logger.info("Admin server started, listening on " + adminPort);
     HealthStatusManager health = new HealthStatusManager();
     server =
         ServerBuilder.forPort(port)
@@ -139,9 +127,6 @@ public class AccountServer {
   private void stop() throws InterruptedException {
     if (server != null) {
       server.shutdown().awaitTermination(30, SECONDS);
-    }
-    if (adminServer != null) {
-      adminServer.shutdown().awaitTermination(30, SECONDS);
     }
   }
 

--- a/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/StatsServer.java
@@ -27,7 +27,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
-import io.grpc.services.AdminInterface;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.examples.wallet.account.AccountGrpc;
@@ -52,10 +51,8 @@ public class StatsServer {
   private static final Logger logger = Logger.getLogger(StatsServer.class.getName());
 
   private Server server;
-  private Server adminServer;
 
   private int port = 18882;
-  private int adminPort = 28882;
   private String accountServer = "localhost:18883";
   private String hostnameSuffix = "";
   private String observabilityProject = "";
@@ -86,8 +83,6 @@ public class StatsServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port = Integer.parseInt(value);
-      } else if ("admin_port".equals(key)) {
-        adminPort = Integer.parseInt(value);
       } else if ("account_server".equals(key)) {
         accountServer = value;
       } else if ("hostname_suffix".equals(key)) {
@@ -109,8 +104,6 @@ public class StatsServer {
               + "\n"
               + "\n  --port=PORT                The port to listen on. Default "
               + s.port
-              + "\n  --admin_port=PORT          The admin port to listen on. Default "
-              + s.adminPort
               + "\n  --account_server=HOST      Address of the account server. Default "
               + s.accountServer
               + "\n  --hostname_suffix=STR      Suffix to append to hostname in response header. "
@@ -130,11 +123,6 @@ public class StatsServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
-    adminServer = ServerBuilder.forPort(adminPort)
-        .addServices(AdminInterface.getStandardServices())
-        .build()
-        .start();
-    logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     exec = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
     HealthStatusManager health = new HealthStatusManager();
@@ -170,9 +158,6 @@ public class StatsServer {
   private void stop() throws InterruptedException {
     if (server != null) {
       server.shutdown().awaitTermination(30, SECONDS);
-    }
-    if (adminServer != null) {
-      adminServer.shutdown().awaitTermination(30, SECONDS);
     }
     if (accountChannel != null) {
       accountChannel.shutdownNow().awaitTermination(5, SECONDS);

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -23,7 +23,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Server;
-import io.grpc.services.AdminInterface;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
@@ -51,9 +50,7 @@ public class WalletServer {
   private static final Logger logger = Logger.getLogger(WalletServer.class.getName());
 
   private Server server;
-  private Server adminServer;
   private int port = 18881;
-  private int adminPort = 28881;
   private String accountServer = "localhost:18883";
   private String statsServer = "localhost:18882";
   private String hostnameSuffix = "";
@@ -85,8 +82,6 @@ public class WalletServer {
       String value = parts[1];
       if ("port".equals(key)) {
         port = Integer.parseInt(value);
-      } else if ("admin_port".equals(key)) {
-        adminPort = Integer.parseInt(value);
       } else if ("account_server".equals(key)) {
         accountServer = value;
       } else if ("stats_server".equals(key)) {
@@ -110,8 +105,6 @@ public class WalletServer {
               + "\n"
               + "\n  --port=PORT                The port to listen on. Default "
               + s.port
-              + "\n  --admin_port=PORT          The admin port to listen on. Default "
-              + s.adminPort
               + "\n  --account_server=HOST      Address of the account server. Default "
               + s.accountServer
               + "\n  --stats_server=HOST        Address of the stats server. Default "
@@ -133,11 +126,6 @@ public class WalletServer {
     if (!observabilityProject.isEmpty()) {
       Observability.registerExporters(observabilityProject);
     }
-    adminServer = ServerBuilder.forPort(adminPort)
-        .addServices(AdminInterface.getStandardServices())
-        .build()
-        .start();
-    logger.info("Admin server started, listening on " + adminPort);
     accountChannel = ManagedChannelBuilder.forTarget(accountServer).usePlaintext().build();
     statsChannel = ManagedChannelBuilder.forTarget(statsServer).usePlaintext().build();
     HealthStatusManager health = new HealthStatusManager();
@@ -173,9 +161,6 @@ public class WalletServer {
   private void stop() throws InterruptedException {
     if (server != null) {
       server.shutdown().awaitTermination(30, SECONDS);
-    }
-    if (adminServer != null) {
-      adminServer.shutdown().awaitTermination(30, SECONDS);
     }
     if (accountChannel != null) {
       accountChannel.shutdownNow().awaitTermination(5, SECONDS);


### PR DESCRIPTION
Reverts GoogleCloudPlatform/traffic-director-grpc-examples#22

This change broke the live examples, because the account service is run without a bootstrap file set.  We need to roll this back ASAP, and start versioning releases here.