### PR TITLE
scripts: add repo_version setting to control what is used by create_service.sh

### DIFF
--- a/scripts/create_service.sh
+++ b/scripts/create_service.sh
@@ -14,6 +14,8 @@ port="$3"
 hostname_suffix="$4"
 shift 4 # Remaining arguments ($@) are passed to the server binary.
 
+repo_version=${repo_version-"master"}
+
 size=2
 if [ "${hostname_suffix}" = "wallet-v2" ]; then
     size=1
@@ -45,7 +47,7 @@ export HOME=/root
 sudo apt-get update -y
 curl -L https://storage.googleapis.com/traffic-director/td-grpc-bootstrap-0.11.0.tar.gz | tar -xz
 ./td-grpc-bootstrap-0.11.0/td-grpc-bootstrap | tee /root/td-grpc-bootstrap.json
-curl -L https://github.com/GoogleCloudPlatform/traffic-director-grpc-examples/archive/master.tar.gz | tar -xz
+curl -L https://github.com/GoogleCloudPlatform/traffic-director-grpc-examples/archive/${repo_version}.tar.gz | tar -xz
 ${build_script}
 sudo systemd-run -E GRPC_XDS_BOOTSTRAP=/root/td-grpc-bootstrap.json \"${server}\" --port=${port} --hostname_suffix=${hostname_suffix} $@"
 


### PR DESCRIPTION
Defaults to `master` for compatibility with existing examples.