### PR TITLE
scripts: fix create_service.sh to use proper directory name

### DIFF
--- a/scripts/create_service.sh
+++ b/scripts/create_service.sh
@@ -14,7 +14,8 @@ port="$3"
 hostname_suffix="$4"
 shift 4 # Remaining arguments ($@) are passed to the server binary.
 
-repo_version=${repo_version-"master"}
+# EXAMPLES_VERSION may be a branch name or a tag in the git repo.
+EXAMPLES_VERSION=${EXAMPLES_VERSION-"master"}
 
 size=2
 if [ "${hostname_suffix}" = "wallet-v2" ]; then
@@ -23,13 +24,13 @@ fi
 
 case "${language}" in
     go)
-        build_script="cd \"traffic-director-grpc-examples-master/go/${service_type}_server\"
-sudo apt-get install -y golang git
+        build_script="cd \"traffic-director-grpc-examples/go/${service_type}_server\"
+sudo apt-get install -y golang
 go build ."
         server="./${service_type}_server"
         ;;
     java)
-        build_script="cd traffic-director-grpc-examples-master/java
+        build_script="cd traffic-director-grpc-examples/java
 sudo apt-get install -y openjdk-11-jdk-headless
 ./gradlew installDist"
         server="./build/install/wallet/bin/${service_type}-server"
@@ -45,9 +46,10 @@ set -ex
 cd /root
 export HOME=/root
 sudo apt-get update -y
+sudo apt-get install -y git
 curl -L https://storage.googleapis.com/traffic-director/td-grpc-bootstrap-0.11.0.tar.gz | tar -xz
 ./td-grpc-bootstrap-0.11.0/td-grpc-bootstrap | tee /root/td-grpc-bootstrap.json
-curl -L https://github.com/GoogleCloudPlatform/traffic-director-grpc-examples/archive/${repo_version}.tar.gz | tar -xz
+git clone -b ${EXAMPLES_VERSION} --single-branch --depth=1 https://github.com/GoogleCloudPlatform/traffic-director-grpc-examples.git
 ${build_script}
 sudo systemd-run -E GRPC_XDS_BOOTSTRAP=/root/td-grpc-bootstrap.json \"${server}\" --port=${port} --hostname_suffix=${hostname_suffix} $@"
 


### PR DESCRIPTION
- Use git instead of curl for a consistent directory
- Change repo_version env var to EXAMPLES_VERSION to be consistent with Google
  bash style and be more expalantory.

cc @lidizheng 
