### PR TITLE
Add option to use xDS creds

### DIFF
--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -1,10 +1,24 @@
 package(default_visibility = ["//visibility:public"])
 
+cc_library(
+    name = "utility",
+    srcs = [
+        "utility.cc",
+        "utility.h",
+    ],
+    defines = ["BAZEL_BUILD"],
+    deps = [
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
 cc_binary(
     name = "client",
     srcs = ["client.cc"],
     defines = ["BAZEL_BUILD"],
     deps = [
+        ":utility",
         "//:stats_proto",
         "//:wallet_proto",
         "@com_github_grpc_grpc//:grpc++",
@@ -21,6 +35,7 @@ cc_binary(
     srcs = ["wallet_server.cc"],
     defines = ["BAZEL_BUILD"],
     deps = [
+        ":utility",
         "//:account_proto",
         "//:stats_proto",
         "//:wallet_proto",
@@ -41,6 +56,7 @@ cc_binary(
     srcs = ["stats_server.cc"],
     defines = ["BAZEL_BUILD"],
     deps = [
+        ":utility",
         "//:account_proto",
         "//:stats_proto",
         "@com_github_grpc_grpc//:grpc++",
@@ -60,6 +76,7 @@ cc_binary(
     srcs = ["account_server.cc"],
     defines = ["BAZEL_BUILD"],
     deps = [
+        ":utility",
         "//:account_proto",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",

--- a/cpp/utility.cc
+++ b/cpp/utility.cc
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "utility.h"
+
+#include <cassert>
+#include <iostream>
+
+#include "absl/memory/memory.h"
+#include "grpcpp/xds_server_builder.h"
+
+namespace traffic_director_grpc_examples {
+
+const char* kArgCreds = "--creds";
+const char* kInsecureCreds = "insecure";
+const char* kXdsCreds = "xds";
+
+const char* ParseCommandLineArgForCredsType(int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    size_t start_pos = arg.find(kArgCreds);
+    if (start_pos != std::string::npos) {
+      start_pos += strlen(kArgCreds);
+      if (arg[start_pos] == '=') {
+        absl::string_view arg_val = arg.substr(start_pos + 1);
+        if (arg_val == kXdsCreds) {
+          return kXdsCreds;
+        } else if (arg_val == kInsecureCreds) {
+          return kInsecureCreds;
+        } else {
+          std::cerr << "Allowed values for --creds are \'xds\', \'insecure\'";
+          exit(1);
+        }
+      } else {
+        std::cerr << "The only correct argument syntax is --creds=<value>";
+        exit(1);
+      }
+    }
+  }
+  return kInsecureCreds;
+}
+
+std::shared_ptr<grpc::ChannelCredentials> GetChannelCredetials(
+    absl::string_view creds_type) {
+  if (creds_type == kInsecureCreds) {
+    return grpc::InsecureChannelCredentials();
+  } else if (creds_type == kXdsCreds) {
+    return grpc::experimental::XdsCredentials(
+        grpc::InsecureChannelCredentials());
+  }
+  assert(0);
+}
+
+std::unique_ptr<grpc::ServerBuilder> GetServerBuilder(
+    absl::string_view creds_type) {
+  if (creds_type == kInsecureCreds) {
+    return absl::make_unique<grpc::ServerBuilder>();
+  } else if (creds_type == kXdsCreds) {
+    return absl::make_unique<grpc::experimental::XdsServerBuilder>();
+  }
+  assert(0);
+}
+
+std::shared_ptr<grpc::ServerCredentials> GetServerCredentials(
+    absl::string_view creds_type) {
+  if (creds_type == kInsecureCreds) {
+    return grpc::InsecureServerCredentials();
+  } else if (creds_type == kXdsCreds) {
+    return grpc::experimental::XdsServerCredentials(
+        grpc::InsecureServerCredentials());
+  }
+  assert(0);
+}
+
+}  // namespace traffic_director_grpc_examples

--- a/cpp/utility.h
+++ b/cpp/utility.h
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <memory>
+
+#include "absl/strings/string_view.h"
+#include "grpcpp/security/credentials.h"
+#include "grpcpp/security/server_credentials.h"
+
+namespace traffic_director_grpc_examples {
+
+extern const char* kArgCreds;
+extern const char* kInsecureCreds;
+extern const char* kXdsCreds;
+
+// Parses command-line args for --creds=<value>
+// Allowed values are 'xds' and 'insecure'.
+// Returns 'insecure' if no matching arg is found.
+const char* ParseCommandLineArgForCredsType(int argc, char** argv);
+
+std::shared_ptr<grpc::ChannelCredentials> GetChannelCredetials(
+    absl::string_view creds_type);
+
+std::unique_ptr<grpc::ServerBuilder> GetServerBuilder(
+    absl::string_view creds_type);
+
+std::shared_ptr<grpc::ServerCredentials> GetServerCredentials(
+    absl::string_view creds_type);
+
+}  // namespace traffic_director_grpc_examples

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -16,23 +16,24 @@
  *
  */
 
-#include <grpcpp/ext/admin_services.h>
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
-#include <grpcpp/opencensus.h>
 #include <unistd.h>
 
 #include <iostream>
 #include <memory>
 #include <string>
 
+#include "grpcpp/ext/admin_services.h"
+#include "grpcpp/ext/proto_server_reflection_plugin.h"
+#include "grpcpp/grpcpp.h"
+#include "grpcpp/health_check_service_interface.h"
+#include "grpcpp/opencensus.h"
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
 #include "opencensus/trace/with_span.h"
 #include "proto/grpc/examples/wallet/account/account.grpc.pb.h"
 #include "proto/grpc/examples/wallet/stats/stats.grpc.pb.h"
 #include "proto/grpc/examples/wallet/wallet.grpc.pb.h"
+#include "utility.h"
 
 using grpc::Channel;
 using grpc::ChannelArguments;
@@ -255,7 +256,8 @@ std::unique_ptr<Server> StartAdminServer(const std::string& port) {
 
 void RunServer(const std::string& port, const std::string& account_server,
                const std::string& stats_server,
-               const std::string& hostname_suffix, const bool v1_behavior) {
+               const std::string& hostname_suffix, const bool v1_behavior,
+               const std::string& creds_type) {
   char base_hostname[256];
   if (gethostname(base_hostname, 256) != 0) {
     sprintf(base_hostname, "%s-%d", "generated", rand() % 1000);
@@ -271,20 +273,24 @@ void RunServer(const std::string& port, const std::string& account_server,
   // channel isn't authenticated (use of InsecureChannelCredentials()).
   ChannelArguments args;
   service.SetStatsClientStub(Stats::NewStub(grpc::CreateCustomChannel(
-      stats_server, grpc::InsecureChannelCredentials(), args)));
+      stats_server,
+      traffic_director_grpc_examples::GetChannelCredetials(creds_type), args)));
   service.SetAccountClientStub(Account::NewStub(grpc::CreateCustomChannel(
-      account_server, grpc::InsecureChannelCredentials(), args)));
+      account_server,
+      traffic_director_grpc_examples::GetChannelCredetials(creds_type), args)));
   // Listen on the given address without any authentication mechanism.
   std::cout << "Wallet server listening on " << server_address << std::endl;
   grpc::EnableDefaultHealthCheckService(true);
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
-  ServerBuilder builder;
-  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  auto builder = traffic_director_grpc_examples::GetServerBuilder(creds_type);
+  builder->AddListeningPort(
+      server_address,
+      traffic_director_grpc_examples::GetServerCredentials(creds_type));
   // Register "service" as the instance through which we'll communicate with
   // clients. In this case it corresponds to an *synchronous* service.
-  builder.RegisterService(&service);
+  builder->RegisterService(&service);
   // Finally assemble the server.
-  std::unique_ptr<Server> server(builder.BuildAndStart());
+  std::unique_ptr<Server> server(builder->BuildAndStart());
   // Wait for the server to shutdown. Note that some other thread must be
   // responsible for shutting down the server for this call to ever return.
   server->Wait();
@@ -305,6 +311,9 @@ int main(int argc, char** argv) {
   std::string arg_str_hostname_suffix("--hostname_suffix");
   std::string arg_str_v1_behavior("--v1_behavior");
   std::string arg_str_gcp_client_project("--gcp_client_project");
+  std::string creds_type =
+      traffic_director_grpc_examples::ParseCommandLineArgForCredsType(argc,
+                                                                      argv);
   for (int i = 1; i < argc; ++i) {
     std::string arg_val = argv[i];
     size_t start_pos = arg_val.find(arg_str_port);
@@ -325,7 +334,8 @@ int main(int argc, char** argv) {
         admin_port = arg_val.substr(start_pos + 1);
         continue;
       } else {
-        std::cout << "The only correct argument syntax is --admin_port=" << std::endl;
+        std::cout << "The only correct argument syntax is --admin_port="
+                  << std::endl;
         return 1;
       }
     }
@@ -405,7 +415,8 @@ int main(int argc, char** argv) {
             << ", stats_server: " << stats_server
             << ", hostname_suffix: " << hostname_suffix
             << ", v1_behavior: " << v1_behavior
-            << ", gcp_client_project: " << gcp_client_project << std::endl;
+            << ", gcp_client_project: " << gcp_client_project
+            << ", creds: " << creds_type << std::endl;
   if (!gcp_client_project.empty()) {
     grpc::RegisterOpenCensusPlugin();
     grpc::RegisterOpenCensusViewsForExport();
@@ -423,6 +434,7 @@ int main(int argc, char** argv) {
         std::move(stats_opts));
   }
   auto admin_server = StartAdminServer(admin_port);
-  RunServer(port, account_server, stats_server, hostname_suffix, v1_behavior);
+  RunServer(port, account_server, stats_server, hostname_suffix, v1_behavior,
+            creds_type);
   return 0;
 }


### PR DESCRIPTION
Based on #33 and #40

Changes -
1) Added command-line argument --creds=<value> where value = [xds | insecure] with insecure being the default when nothing is specified.
2) Based on #40, `XdsServerBuilder` will only be used when the creds type is xds. We might want to change this to use `XdsServerBuilder` for insecure creds too in the future. Currently, it does not matter much since security is the only server-side feature we have, but would probably need to change when we have other features too. We can probably include more knobs too to still allow users to test these examples without needing to set-up the control plane (traffic-director) for the server, but we can punt on that decision for now. 

Notes -
It might be easier for future changes to just use gflags for command-line parsing. Opened #42 for that.