### PR TITLE
Update the build script for Go

### DIFF
--- a/scripts/create_service.sh
+++ b/scripts/create_service.sh
@@ -31,8 +31,6 @@ wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
 sudo tar -C /usr/local -xvf go1.16.5.linux-amd64.tar.gz
 sudo cp /usr/local/go/bin/go /usr/bin/go
 cd \"traffic-director-grpc-examples/go/${service_type}_server\"
-go build .
-go get google.golang.org/grpc
 go build ."
         server="./${service_type}_server"
         ;;

--- a/scripts/create_service.sh
+++ b/scripts/create_service.sh
@@ -26,8 +26,13 @@ fi
 
 case "${language}" in
     go)
-        build_script="cd \"traffic-director-grpc-examples/go/${service_type}_server\"
-sudo apt-get install -y golang
+        build_script="sudo apt-get install -y wget
+wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
+sudo tar -C /usr/local -xvf go1.16.5.linux-amd64.tar.gz
+sudo cp /usr/local/go/bin/go /usr/bin/go
+cd \"traffic-director-grpc-examples/go/${service_type}_server\"
+go build .
+go get google.golang.org/grpc
 go build ."
         server="./${service_type}_server"
         ;;


### PR DESCRIPTION
The version of Go available from apt-get is Go1.11.x, which is really
old, and the xds implementation in gRPC-Go uses features not supported
in Go1.11. So, we need to be using the latest version of Go.

Summary of changes
* Pull the latest version of Go from the downloads page
* Extract the Go runtime/toolchain into /usr/local
* Copy the `go` command line binary into /usr/bin so that it is
  available in $PATH
* Do a `go get` on the gRPC-Go module to pull in the latest version

