### PR TITLE
java: remove the unnecessary line that creates an ununused channel

### DIFF
--- a/java/src/main/java/io/grpc/examples/wallet/Client.java
+++ b/java/src/main/java/io/grpc/examples/wallet/Client.java
@@ -85,7 +85,6 @@ public class Client {
             ? XdsChannelCredentials.create(InsecureChannelCredentials.create())
             : InsecureChannelCredentials.create();
 
-    Grpc.newChannelBuilder(target, channelCredentials).build();
     ManagedChannel managedChannel = Grpc.newChannelBuilder(target, channelCredentials).build();
     Metadata headers = new Metadata();
     if ("Alice".equals(user)) {


### PR DESCRIPTION
A fix for an unused channel that caused "...Channel ... was not shutdown properly!!" message