### PR TITLE
Update kokoro build script for Go

### DIFF
--- a/test/kokoro/grpc_wallet.sh
+++ b/test/kokoro/grpc_wallet.sh
@@ -11,20 +11,18 @@ pushd java
 ./gradlew build
 popd
 
-export GOPATH="${HOME}/gopath"
+# Download the latest Go version in tmpdir and modify $PATH to include the
+# extracted `go` binary.
+walletBaseDir=${PWD}
+cd ${TMPDIR}
+wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
+tar -xvf go1.16.5.linux-amd64.tar.gz
+export GOROOT=${PWD}/go
+export PATH="${PWD}/go/bin:${PATH}"
+cd ${walletBaseDir}
+
 pushd go
-pushd account_server
-go build
-popd
-pushd stats_server
-go build
-popd
-pushd wallet_client
-go build
-popd
-pushd wallet_server
-go build
-popd
+go build google.golang.org/grpc/grpc-wallet/...
 popd
 
 tools/bazel build cpp/...


### PR DESCRIPTION
- Use a newer version of Go. The default version installed in GCP_UBUNTU
  images is Go 1.12 which is too old for our needs.