### PR TITLE
Update wallet server to support retry example

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,9 +26,9 @@ switched_rules_by_language(
 
 http_archive(
     name = "com_github_grpc_grpc",
-    strip_prefix = "grpc-1.37.1",
+    strip_prefix = "grpc-1.40.0",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.37.1.tar.gz",
+        "https://github.com/grpc/grpc/archive/v1.40.0.tar.gz",
     ],
 )
 

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -84,7 +84,7 @@ class WalletServiceImpl final : public Wallet::Service {
     request.set_token(token_);
     ClientContext context;
     context.set_wait_for_ready(true);
-    if (route_ != nullptr)
+    if (!route_.empty())
       context.AddMetadata("route", route_);
     GetUserInfoResponse response;
     Status status = account_stub_->GetUserInfo(&context, request, &response);

--- a/cpp/wallet_server.cc
+++ b/cpp/wallet_server.cc
@@ -77,11 +77,15 @@ class WalletServiceImpl final : public Wallet::Service {
         token_ = std::string(iter->second.data(), iter->second.size());
       else if (iter->first == "membership")
         membership_ = std::string(iter->second.data(), iter->second.size());
+      else if (iter->first == "route")
+        route_ = std::string(iter->second.data(), iter->second.size());
     }
     GetUserInfoRequest request;
     request.set_token(token_);
     ClientContext context;
     context.set_wait_for_ready(true);
+    if (route_ != nullptr)
+      context.AddMetadata("route", route_);
     GetUserInfoResponse response;
     Status status = account_stub_->GetUserInfo(&context, request, &response);
     if (status.ok()) {
@@ -239,6 +243,7 @@ class WalletServiceImpl final : public Wallet::Service {
   std::string token_;
   std::string user_ = "Alice";
   std::string membership_ = "premium";
+  std::string route_;
   std::map<std::string, std::map<std::string, int>> user_coin_map_ = {
       {"Alice", {{"cd0aa985", 314}, {"454349e4", 159}}},
       {"Bob", {{"148de9c5", 271}, {"2e7d2c03", 828}}}};

--- a/go/utility/utility.go
+++ b/go/utility/utility.go
@@ -93,6 +93,10 @@ func ValidateMembership(inCtx context.Context, accountClient accountpb.AccountCl
 	if requestedMembership != "normal" && requestedMembership != "premium" {
 		return false, "", "", "", status.Error(codes.Unauthenticated, "unknown user membership")
 	}
+	routes, ok := inMd["route"]
+	if ok {
+	  inCtx = metadata.NewOutgoingContext(inCtx, metadata.Pairs("route", routes[0]))
+	}
 
 	// Perform RPC to account client.
 	var header metadata.MD

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -17,7 +17,7 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-def grpcVersion = '1.37.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.40.0' // CURRENT_GRPC_VERSION
 def opencensusVersion = '0.28.0'
 def protobufVersion = '3.12.0'
 def protocVersion = protobufVersion

--- a/java/src/main/java/io/grpc/examples/wallet/Client.java
+++ b/java/src/main/java/io/grpc/examples/wallet/Client.java
@@ -250,7 +250,9 @@ public class Client {
               + c.unaryWatch
               + "\n  --creds=insecure|xds  . Type of credentials to use on the client. "
               + "Default "
-              + c.credentialsType.toString().toLowerCase());
+              + c.credentialsType.toString().toLowerCase()
+              + "\n  --route                   A string value to set for the 'route' header. "
+              + "Optional");
       System.exit(1);
     }
   }

--- a/java/src/main/java/io/grpc/examples/wallet/WalletInterceptors.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletInterceptors.java
@@ -23,6 +23,7 @@ import io.grpc.Contexts;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
@@ -38,12 +39,15 @@ final class WalletInterceptors {
 
   public static final Context.Key<String> TOKEN_KEY = Context.key("token");
   public static final Context.Key<String> MEMBERSHIP_KEY = Context.key("membership");
+  public static final Context.Key<String> ROUTE_KEY = Context.key("route");
   public static final Metadata.Key<String> TOKEN_MD_KEY =
       Metadata.Key.of("Authorization", ASCII_STRING_MARSHALLER);
   public static final Metadata.Key<String> MEMBERSHIP_MD_KEY =
       Metadata.Key.of("membership", ASCII_STRING_MARSHALLER);
   public static final Metadata.Key<String> HOSTNAME_MD_KEY =
       Metadata.Key.of("hostname", ASCII_STRING_MARSHALLER);
+  public static final Metadata.Key<String> ROUTE_MD_KEY =
+      Metadata.Key.of("route", ASCII_STRING_MARSHALLER);
 
   /** Adds the server hostname to response metadata. */
   static class HostnameInterceptor implements ServerInterceptor {
@@ -104,6 +108,18 @@ final class WalletInterceptors {
       }
       Context newContext =
           Context.current().withValue(TOKEN_KEY, token).withValue(MEMBERSHIP_KEY, membership);
+      return Contexts.interceptCall(newContext, call, requestHeaders, next);
+    }
+  }
+
+  /** Extracts route header value from metadata and inserts into context. */
+  static class RouteHeaderInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+        Metadata requestHeaders, ServerCallHandler<ReqT, RespT> next) {
+      String routeVal = requestHeaders.get(ROUTE_MD_KEY);
+      Context newContext =
+          Context.current().withValue(ROUTE_KEY, routeVal);
       return Contexts.interceptCall(newContext, call, requestHeaders, next);
     }
   }

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -171,32 +171,19 @@ public class WalletServer {
         credentialsType == CredentialsType.XDS
             ? XdsServerCredentials.create(InsecureServerCredentials.create())
             : InsecureServerCredentials.create();
-    if (credentialsType == CredentialsType.XDS) {
-      server =
-          XdsServerBuilder.forPort(port, serverCredentials)
-              .addService(
-                  ServerInterceptors.intercept(
-                      new WalletImpl(accountChannel, statsChannel, v1Behavior),
-                      new WalletInterceptors.HostnameInterceptor(),
-                      new WalletInterceptors.AuthInterceptor(),
-                      new RouteHeaderInterceptor()))
-              .addService(ProtoReflectionService.newInstance())
-              .addService(health.getHealthService())
-              .build()
-              .start();
-    } else {
-      server =
-          ServerBuilder.forPort(port)
-              .addService(
-                  ServerInterceptors.intercept(
-                      new WalletImpl(accountChannel, statsChannel, v1Behavior),
-                      new WalletInterceptors.HostnameInterceptor(),
-                      new WalletInterceptors.AuthInterceptor()))
-              .addService(ProtoReflectionService.newInstance())
-              .addService(health.getHealthService())
-              .build()
-              .start();
-    }
+
+    server =
+        XdsServerBuilder.forPort(port, serverCredentials)
+            .addService(
+                ServerInterceptors.intercept(
+                    new WalletImpl(accountChannel, statsChannel, v1Behavior),
+                    new WalletInterceptors.HostnameInterceptor(),
+                    new WalletInterceptors.AuthInterceptor(),
+                    new RouteHeaderInterceptor()))
+            .addService(ProtoReflectionService.newInstance())
+            .addService(health.getHealthService())
+            .build()
+            .start();
     health.setStatus("", ServingStatus.SERVING);
     logger.info("Server started, listening on " + port);
     Runtime.getRuntime()

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -263,9 +263,7 @@ public class WalletServer {
                 GetUserInfoRequest.newBuilder().setToken(token).build());
       } catch (StatusRuntimeException e) {
         logger.log(Level.WARNING, "Account RPC failed: {0}", e.getStatus());
-        throw Status.INTERNAL
-            .withDescription("Failed to connect to account server " + e.getMessage())
-            .asRuntimeException();
+        throw e;
       }
       if ("premium".equals(membership) && userInfo.getMembership() != MembershipType.PREMIUM) {
         throw Status.UNAUTHENTICATED

--- a/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
+++ b/java/src/main/java/io/grpc/examples/wallet/WalletServer.java
@@ -171,19 +171,33 @@ public class WalletServer {
         credentialsType == CredentialsType.XDS
             ? XdsServerCredentials.create(InsecureServerCredentials.create())
             : InsecureServerCredentials.create();
-
-    server =
-        XdsServerBuilder.forPort(port, serverCredentials)
-            .addService(
-                ServerInterceptors.intercept(
-                    new WalletImpl(accountChannel, statsChannel, v1Behavior),
-                    new WalletInterceptors.HostnameInterceptor(),
-                    new WalletInterceptors.AuthInterceptor(),
-                    new RouteHeaderInterceptor()))
-            .addService(ProtoReflectionService.newInstance())
-            .addService(health.getHealthService())
-            .build()
-            .start();
+    if (credentialsType == CredentialsType.XDS) {
+      server =
+          XdsServerBuilder.forPort(port, serverCredentials)
+              .addService(
+                  ServerInterceptors.intercept(
+                      new WalletImpl(accountChannel, statsChannel, v1Behavior),
+                      new WalletInterceptors.HostnameInterceptor(),
+                      new WalletInterceptors.AuthInterceptor(),
+                      new RouteHeaderInterceptor()))
+              .addService(ProtoReflectionService.newInstance())
+              .addService(health.getHealthService())
+              .build()
+              .start();
+    } else {
+      server =
+          ServerBuilder.forPort(port)
+              .addService(
+                  ServerInterceptors.intercept(
+                      new WalletImpl(accountChannel, statsChannel, v1Behavior),
+                      new WalletInterceptors.HostnameInterceptor(),
+                      new WalletInterceptors.AuthInterceptor(),
+                      new RouteHeaderInterceptor()))
+              .addService(ProtoReflectionService.newInstance())
+              .addService(health.getHealthService())
+              .build()
+              .start();
+    }
     health.setStatus("", ServingStatus.SERVING);
     logger.info("Server started, listening on " + port);
     Runtime.getRuntime()


### PR DESCRIPTION
Change wallet server as described in the retry example http://go/grpc-wallet-example-update-for-retry

> forward the 'route' request header from wallet service to account service