### PR TITLE
Fix java build after version bumped to 1.40

### DIFF
--- a/java/src/test/java/io/grpc/examples/wallet/ObservabilityTest.java
+++ b/java/src/test/java/io/grpc/examples/wallet/ObservabilityTest.java
@@ -110,16 +110,16 @@ public class ObservabilityTest {
   }
 
   private class RecordingTraceExporter extends SpanExporter.Handler {
-    // The trace span exported by the client (identified by a null parent span)
+    // The trace span exported by the client
     SpanData clientSpanData = null;
-    // The trace span exported by the server (identified by a non-null parent span)
+    // The trace span exported by the server (identified by span name with prefix "Recv.")
     SpanData serverSpanData = null;
     CountDownLatch latch = new CountDownLatch(2);
 
     @Override
     public void export(Collection<SpanData> spanDataList) {
       for (SpanData sd : spanDataList) {
-        if (sd.getParentSpanId() != null) {
+        if (sd.getName().startsWith("Recv.")) {
           assertThat(serverSpanData).isNull();
           serverSpanData = sd;
         } else {


### PR DESCRIPTION
After version bumped to 1.40, the client side trace span exported is the Attempt span with a parent, and the test need be updated accordingly.