### PR TITLE
Fix a couple of bugs in url map scripts

### DIFF
--- a/scripts/config_traffic_director.sh
+++ b/scripts/config_traffic_director.sh
@@ -7,7 +7,7 @@ set -x
 
 PROJECT_ID=$(gcloud config list --format 'value(core.project)')
 BS_PREFIX=projects/${PROJECT_ID}/global/backendServices/grpcwallet
-gcloud compute url-maps import grpcwallet-url-map --source=<(sed -e "s/\$BS_PREFIX/${BS_PREFIX}/" url_map_template.yaml)
+gcloud compute url-maps import grpcwallet-url-map --source=<(sed -e "s:\$BS_PREFIX:${BS_PREFIX}:" url_map_template.yaml)
 
 gcloud compute target-grpc-proxies create grpcwallet-proxy \
     --url-map grpcwallet-url-map \

--- a/scripts/url_map_template.yaml
+++ b/scripts/url_map_template.yaml
@@ -26,15 +26,15 @@ pathMatchers:
       headerMatches:
       - headerName: route
         exactMatch: account-fault
-      priority: 0
-      routeAction:
-        weightedBackendServices:
-        - backendService: $BS_PREFIX-account-service
-          weight: 100
-        faultInjectionPolicy:
-          abort:
-            httpStatus: 503
-            percentage: 30
+    priority: 0
+    routeAction:
+      weightedBackendServices:
+      - backendService: $BS_PREFIX-account-service
+        weight: 100
+      faultInjectionPolicy:
+        abort:
+          httpStatus: 503
+          percentage: 30
 
 - name: grpcwallet-stats-path-matcher
   defaultService: $BS_PREFIX-stats-service


### PR DESCRIPTION
The replacement `${BS_PREFIX}` in the sed command 

```
sed -e "s/\$BS_PREFIX/${BS_PREFIX}/" url_map_template.yaml
```

contains '/', so we need to use a different delimiter. 

Also fix indent in the url map template.