### PR TITLE
Update java to use 1.40.1 patch release

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -17,7 +17,7 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-def grpcVersion = '1.40.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.40.1' // CURRENT_GRPC_VERSION
 def opencensusVersion = '0.28.0'
 def protobufVersion = '3.12.0'
 def protocVersion = protobufVersion


### PR DESCRIPTION
1.40.1 enables RING_HASH by default and fixed a related bug.