### PR TITLE
Set ROUN_RONBIN for affinity BS initially

### DIFF
--- a/scripts/create_service.sh
+++ b/scripts/create_service.sh
@@ -114,6 +114,8 @@ healthChecks:
 loadBalancingScheme: INTERNAL_SELF_MANAGED
 name: grpcwallet-${hostname_suffix}-affinity-service
 portName: grpcwallet-${service_type}-port
-protocol: GRPC"
+protocol: GRPC
+sessionAffinity: NONE
+localityLbPolicy: ROUND_ROBIN"
     gcloud compute backend-services import grpcwallet-${hostname_suffix}-affinity-service --global <<< "${backend_config}"
 fi


### PR DESCRIPTION
Explicitly set ROUN_RONBIN lbPolicy and NONE sessionAffinity initially for affinity BS, then we can backup the config using
```
gcloud compute backend-services export grpcwallet-wallet-v1-affinity-service --destination=bs_config.yaml --global
```

before running affinity example

and then restore the config using
```
gcloud compute backend-services import grpcwallet-wallet-v1-affinity-service --source=bs_config.yaml --global
```

after running the affinity example.

Otherwise, after the restore command, the sessionAffinity field is still HEADER_FIELD.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR