### PR TITLE
Add new Dockerfile for Go to build image with all binaries

### DIFF
--- a/gke-scripts/00-common-env.sh
+++ b/gke-scripts/00-common-env.sh
@@ -87,13 +87,15 @@ export CLIENT_IMAGE="gcr.io/${PROJECT_ID}/psms-wallet-example:1.00"
 
 # Private CA resources
 export ROOT_CA_NAME="wallet-root-ca"
-export ROOT_CA_LOCATION="us-east1"
 export ROOT_CA_ORGANIZATION="TestCorpLLC"
-export ROOT_CA_URI="//privateca.googleapis.com/projects/${PROJECT_ID}/locations/${ROOT_CA_LOCATION}/certificateAuthorities/${ROOT_CA_NAME}"
+export ROOT_CA_POOL_LOCATION="us-east1"
+export ROOT_CA_POOL_NAME="wallet-root-ca-pool"
+export ROOT_CA_POOL_URI="//privateca.googleapis.com/projects/${PROJECT_ID}/locations/${ROOT_CA_POOL_LOCATION}/caPools/${ROOT_CA_POOL_NAME}"
 export SUBORDINATE_CA_NAME="wallet-subordinate-ca"
 export SUBORDINATE_CA_ORGANIZATION="TestCorpLLC"
-export SUBORDINATE_CA_LOCATION="us-east1"
-export SUBORDINATE_CA_URI="//privateca.googleapis.com/projects/${PROJECT_ID}/locations/${SUBORDINATE_CA_LOCATION}/certificateAuthorities/${SUBORDINATE_CA_NAME}"
+export SUBORDINATE_CA_POOL_NAME="wallet-subordinate-ca-pool"
+export SUBORDINATE_CA_POOL_LOCATION="us-east1"
+export SUBORDINATE_CA_POOL_URI="//privateca.googleapis.com/projects/${PROJECT_ID}/locations/${SUBORDINATE_CA_POOL_LOCATION}/caPools/${SUBORDINATE_CA_POOL_NAME}"
 
 # Security related configuration
 export SERVER_MTLS_POLICY_NAME="server-mtls-policy"

--- a/gke-scripts/00-common-env.sh
+++ b/gke-scripts/00-common-env.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Basic project level configuration
+export ME="YOUR_GOOGLE_EMAIL"
 export PROJECT_ID="YOUR_PROJECT_ID"
 export PROJECT_NUM=$(gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)")
 export GSA_EMAIL=${PROJECT_NUM}-compute@developer.gserviceaccount.com
@@ -27,7 +28,7 @@ export ACCOUNT_ADMIN_PORT="50056"
 export ACCOUNT_NEG_NAME="account-neg"
 export ACCOUNT_SERVICE_IMAGE="gcr.io/${PROJECT_ID}/psms-wallet-example:1.00"
 export ACCOUNT_BACKEND_SERVICE_NAME="account-backend-service"
-export ACCOUNT_SERVER_CMD="/build/install/wallet/bin/account-server"
+export ACCOUNT_SERVER_CMD="./account-server"
 
 # Kubernetes and Traffic Director configuration for the Stats service
 export STATS_SERVICE_NAME="stats-service"
@@ -38,7 +39,7 @@ export STATS_ADMIN_PORT="50054"
 export STATS_NEG_NAME="stats-neg"
 export STATS_SERVICE_IMAGE="gcr.io/${PROJECT_ID}/psms-wallet-example:1.00"
 export STATS_BACKEND_SERVICE_NAME="stats-backend-service"
-export STATS_SERVER_CMD="/build/install/wallet/bin/stats-server"
+export STATS_SERVER_CMD="./stats-server"
 
 # Kubernetes and Traffic Director configuration for the Stats Premium service
 export STATS_PREMIUM_SERVICE_NAME="stats-premium-service"
@@ -59,7 +60,7 @@ export WALLET_V1_ADMIN_PORT="50052"
 export WALLET_V1_NEG_NAME="wallet-v1-neg"
 export WALLET_V1_SERVICE_IMAGE="gcr.io/${PROJECT_ID}/psms-wallet-example:1.00"
 export WALLET_V1_BACKEND_SERVICE_NAME="wallet-v1-backend-service"
-export WALLET_SERVER_CMD="/build/install/wallet/bin/wallet-server"
+export WALLET_SERVER_CMD="./wallet-server"
 
 # Kubernetes and Traffic Director configuration for the Wallet V2 service
 export WALLET_V2_SERVICE_NAME="wallet-v2-service"

--- a/gke-scripts/20-cluster.sh
+++ b/gke-scripts/20-cluster.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+set -euxo pipefail
+
+. ./00-common-env.sh
+
 function create_cluster {
   gcloud beta container clusters create ${CLUSTER_NAME} \
     --zone=${CLUSTER_ZONE} \

--- a/gke-scripts/30-private-ca-setup.sh
+++ b/gke-scripts/30-private-ca-setup.sh
@@ -6,19 +6,25 @@ set -euxo pipefail
 
 function create_private_ca_resources {
   # Create a ROOT CA.
-  gcloud beta privateca roots create ${ROOT_CA_NAME} \
+  gcloud privateca pools create ${ROOT_CA_POOL_NAME} \
+    --location ${ROOT_CA_POOL_LOCATION} \
+    --tier enterprise
+  gcloud privateca roots create ${ROOT_CA_NAME} \
+    --pool ${ROOT_CA_POOL_NAME}
     --subject "CN=${ROOT_CA_NAME}, O=${ROOT_CA_ORGANIZATION}" \
     --max-chain-length=1 \
-    --location ${ROOT_CA_LOCATION} \
-    --tier enterprise
+    --location ${ROOT_CA_POOL_LOCATION} \
 
   # Create a subordinate CA.
-  gcloud beta privateca subordinates create ${SUBORDINATE_CA_NAME} \
-    --issuer ${ROOT_CA_NAME} \
-    --issuer-location ${ROOT_CA_LOCATION} \
-    --subject "CN=${SUBORDINATE_CA_NAME}, O=${SUBORDINATE_CA_ORGANIZATION}" \
-    --location ${SUBORDINATE_CA_LOCATION} \
+  gcloud privateca pools create ${SUBORDINATE_CA_POOL_NAME} \
+    --location ${SUBORDINATE_CA_POOL_LOCATION} \
     --tier devops
+  gcloud privateca subordinates create ${SUBORDINATE_CA_NAME} \
+    --pool ${SUBORDINATE_CA_POOL_NAME} \
+    --location ${SUBORDINATE_CA_POOL_LOCATION} \
+    --issuer-pool ${ROOT_CA_POOL_NAME} \
+    --issuer-location ${ROOT_CA_POOL_LOCATION} \
+    --subject "CN=SUBORDINATE_CA_NAME, O=SUBORDINATE_CA_ORGANIZATION" \
 
   # Grant PrivateCA admin to yourself so that you can grant other privileges to
   # the GKE service account.

--- a/gke-scripts/30-private-ca-setup.sh
+++ b/gke-scripts/30-private-ca-setup.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+set -euxo pipefail
+
+. ./00-common-env.sh
+
 function create_private_ca_resources {
   # Create a ROOT CA.
   gcloud beta privateca roots create ${ROOT_CA_NAME} \

--- a/gke-scripts/ClientDeployment.yaml
+++ b/gke-scripts/ClientDeployment.yaml
@@ -34,8 +34,10 @@ spec:
         env:
         - name: GRPC_XDS_BOOTSTRAP
           value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-        - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
-          value: "true"
+        - name: GRPC_GO_LOG_SEVERITY_LEVEL
+          value: "info"
+        - name: GRPC_GO_LOG_VERBOSITY_LEVEL
+          value: "2"
         resources:
           limits:
             cpu: 800m
@@ -48,12 +50,11 @@ spec:
           mountPath: /tmp/grpc-xds/
       initContainers:
       - name: grpc-td-init
-        image: gcr.io/trafficdirector-prod/td-grpc-bootstrap:0.12.0-rc1
+        image: gcr.io/trafficdirector-prod/td-grpc-bootstrap:0.12.0
         imagePullPolicy: Always
         args:
         - --output
         - "/tmp/bootstrap/td-grpc-bootstrap.json"
-        - --include-psm-security-experimental
         resources:
           limits:
             cpu: 100m

--- a/gke-scripts/Deployment.yaml
+++ b/gke-scripts/Deployment.yaml
@@ -25,8 +25,6 @@ spec:
         env:
         - name: GRPC_XDS_BOOTSTRAP
           value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-        - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
-          value: "true"
         - name: GRPC_GO_LOG_SEVERITY_LEVEL
           value: "info"
         - name: GRPC_GO_LOG_VERBOSITY_LEVEL
@@ -46,12 +44,11 @@ spec:
           mountPath: /tmp/grpc-xds/
       initContainers:
       - name: grpc-td-init
-        image: gcr.io/trafficdirector-prod/td-grpc-bootstrap:0.12.0-rc1
+        image: gcr.io/trafficdirector-prod/td-grpc-bootstrap:0.12.0
         imagePullPolicy: Always
         args:
         - --output
         - "/tmp/bootstrap/td-grpc-bootstrap.json"
-        - --include-psm-security-experimental
         resources:
           limits:
             cpu: 100m

--- a/gke-scripts/README.md
+++ b/gke-scripts/README.md
@@ -29,28 +29,27 @@ Execute the following steps in the given order:
    to demonstrate that 'FetchBalance' gets responses from 'wallet-v1' (40%)
    and 'wallet-v2' (60%).
 
-#### Java
 ```shell
-/build/install/wallet/bin/client balance --creds=xds --wallet_server="xds:///wallet.grpcwallet.io" --unary_watch=true
+./wallet-client balance --creds=xds --wallet_server="xds:///wallet.grpcwallet.io" --unary_watch=true
 ```
+
  * The following command calls the streaming RPC 'WatchBalance' from 'wallet-service'.
    The RPC path matches the service prefix, so all requests are sent to 'wallet-v2'.
 
-#### Java
 ```shell
-/build/install/wallet/bin/client balance --creds=xds --wallet_server="xds:///wallet.grpcwallet.io" --watch=true
+./wallet-client balance --creds=xds --wallet_server="xds:///wallet.grpcwallet.io" --watch=true
+
 ```
  * The following commands call 'WatchPrice' from 'stats-service'. It sends the 
    user's membership (premium or not) in metadata. Premium requests are all sent
    to 'stats-premium' and get faster responses. Alice's requests always go to 
    premium and Bob's go to regular.
 
-
-#### Java
 ```shell
-/build/install/wallet/bin/client price --creds=xds --stats_server="xds:///stats.grpcwallet.io" --watch=true --user=Bob
-/build/install/wallet/bin/client price --creds=xds --stats_server="xds:///stats.grpcwallet.io" --watch=true --user=Alice
+./wallet-client price --creds=xds --stats_server="xds:///stats.grpcwallet.io" --watch=true --user=Bob
+./wallet-client price --creds=xds --stats_server="xds:///stats.grpcwallet.io" --watch=true --user=Alice
 ```
+
 ## Cleanup
 
 To clean up all the artifacts created run `./cleanup.sh` 

--- a/gke-scripts/TrustConfig.yaml
+++ b/gke-scripts/TrustConfig.yaml
@@ -1,0 +1,13 @@
+apiVersion: security.cloud.google.com/v1alpha1
+kind: TrustConfig
+metadata:
+  name: default
+spec:
+  # You must include a trustStores entry for the trust domain that
+  # your cluster is enrolled in.
+  trustStores:
+  - trustDomain: ${PROJECT_ID}.svc.id.goog
+    # Trust identities in this trustDomain if they appear in a certificate
+    # that chains up to this root CA.
+    trustAnchors:
+    - certificateAuthorityServiceURI: ${ROOT_CA_URI}

--- a/gke-scripts/WorkloadCertificateConfig.yaml
+++ b/gke-scripts/WorkloadCertificateConfig.yaml
@@ -1,0 +1,40 @@
+apiVersion: security.cloud.google.com/v1alpha1
+kind: WorkloadCertificateConfig
+metadata:
+  name: default
+spec:
+  # Required. The SPIFFE trust domain. This must match your clusters
+  # Workload Identity pool.
+  trustDomain: ${PROJECT_ID}.svc.id.goog
+
+  # Required. The CA service that issues your certificates.
+  certificateAuthorityConfig:
+    certificateAuthorityServiceConfig:
+      endpointURI: ${SUBORDINATE_CA_URI}
+
+  # Required. The key algorithm to use. Choice of RSA or ECDSA.
+  #
+  # To maximize compatibility with various TLS stacks, your workloads
+  # should use keys of the same family as your root and subordinate CAs.
+  #
+  # To use RSA, specify configuration such as:
+  #   keyAlgorithm:
+  #     rsa:
+  #       modulusSize: 4096
+  #
+  # Currently, the supported ECDSA curves are "P256" and "P384", and the
+  # supported RSA modulus sizes are 2048, 3072 and 4096.
+  keyAlgorithm:
+    rsa:
+      modulusSize: 4096
+
+  # Optional. Validity duration of issued certificates, in seconds.
+  #
+  # Defaults to 86400 (1 day) if not specified.
+  validityDurationSeconds: 86400
+
+  # Optional. Try to start rotating the certificate once this
+  # percentage of validityDurationSeconds is remaining.
+  #
+  # Defaults to 50 if not specified.
+  rotationWindowPercentage: 50

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,0 +1,35 @@
+# Dockerfile for building an image with all binaries required for the wallet
+# example. To build the image, run the following command from the
+# traffic-director-grpc-examples directory:
+# docker build -t <TAG> -f go/Dockerfile .
+
+FROM golang:1.16-alpine as build
+
+# Make a traffic-director-grpc-examples directory and copy the repo into it.
+WORKDIR /traffic-director-grpc-examples
+COPY . .
+
+# Build static binaries without cgo so that we can copy just the binary in the
+# final image, and can get rid of the Go compiler and other dependencies.
+WORKDIR /traffic-director-grpc-examples/go/account_server
+RUN go build -o account-server -tags osusergo,netgo main.go
+
+WORKDIR /traffic-director-grpc-examples/go/stats_server
+RUN go build -o stats-server -tags osusergo,netgo main.go
+
+WORKDIR /traffic-director-grpc-examples/go/wallet_server
+RUN go build -o wallet-server -tags osusergo,netgo main.go
+
+WORKDIR /traffic-director-grpc-examples/go/wallet_client
+RUN go build -o wallet-client -tags osusergo,netgo main.go
+
+# Second stage of the build which copies over only the required binaries and
+# skips the Go compiler and traffic-director-grpc-examples repo from the earlier
+# stage. This significantly reduces the docker image size.
+FROM alpine
+COPY --from=build /traffic-director-grpc-examples/go/account_server/account-server .
+COPY --from=build /traffic-director-grpc-examples/go/stats_server/stats-server .
+COPY --from=build /traffic-director-grpc-examples/go/wallet_server/wallet-server .
+COPY --from=build /traffic-director-grpc-examples/go/wallet_client/wallet-client .
+ENV GRPC_GO_LOG_VERBOSITY_LEVEL=2
+ENV GRPC_GO_LOG_SEVERITY_LEVEL="info"


### PR DESCRIPTION
Summary of changes:
- Add a `Dockerfile` to build all Go binaries.
  - Places all the binaries at the root of the filesystem, making them accessible at `./foo-server` or `./foo-client`
- Change the server commands in `00-common-env.sh`
- Make the scripts to create cluster and Private CA resources executable
- Remove PSM security experimental env var from the deployment
- Switch to the latest bootstrap generator release in the deployment
- Skip the `--include-psm-security-experimental` flag
- Remove the `Java` tag on the instructions to run the client. If all languages have the binaries in the same place, we need not have language specific instructions
- Add `gke-scripts/TrustConfig.yaml` and `gke-scripts/WorkloadCertificateConfig.yaml` which are referenced from the script used to create Private CA resources