### PR TITLE
Fixups for grpc_wallet.sh to pass on non-legacy kokoro image

### DIFF
--- a/test/kokoro/grpc_wallet.sh
+++ b/test/kokoro/grpc_wallet.sh
@@ -13,8 +13,9 @@ popd
 
 # Download the latest Go version in tmpdir and modify $PATH to include the
 # extracted `go` binary.
-walletBaseDir=${PWD}
-cd ${TMPDIR}
+walletBaseDir="${PWD}"
+kokoroTmpDir="${TMPDIR:-/tmpfs/tmp}"
+cd "${kokoroTmpDir}"
 wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
 tar -xvf go1.16.5.linux-amd64.tar.gz
 export GOROOT=${PWD}/go


### PR DESCRIPTION
Unblock upgrade to ubuntu20.04 image (see internal cl/483942573).

The idea is that the new worker image doesn't have the "TMPDIR" env variable setup (there's nothing standard about it), so updating the script to fallback to the kokoro default (/tmpfs/tmp) if the variable is not set.

The grpc_wallet jobs passed on the ubuntu20.04 image with this change:
[adhoc run](https://source.cloud.google.com/results/invocations/c2797854-7f7f-4cb5-bd50-c923d561961f/log)